### PR TITLE
Fix inference job default output table name

### DIFF
--- a/{{cookiecutter.project_name}}/databricks-config/prod/inference-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/inference-job.tf
@@ -27,7 +27,7 @@ resource "databricks_job" "batch_inference_job" {
       env = local.env
       # TODO: Specify input and output table names for batch inference here
       input_table_name  = ""
-      output_table_name = "{{cookiecutter.project_name}}_predictions"
+      output_table_name = "{{cookiecutter.project_name_alphanumeric}}_predictions"
     }
   }
 

--- a/{{cookiecutter.project_name}}/databricks-config/staging/inference-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/inference-job.tf
@@ -27,7 +27,7 @@ resource "databricks_job" "batch_inference_job" {
       env = local.env
       # TODO: Specify input and output table names for batch inference here
       input_table_name  = ""
-      output_table_name = "{{cookiecutter.project_name}}_predictions"
+      output_table_name = "{{cookiecutter.project_name_alphanumeric}}_predictions"
     }
   }
 


### PR DESCRIPTION
Fix the default output table name for batch inference; only alphanumeric characters are allowed in unescaped Spark table names, so use the alphanumeric version of the project name in the output table name

Before:
<img width="1160" alt="image" src="https://user-images.githubusercontent.com/2358483/190969878-2589af47-7556-4e3b-9f99-af09941e998b.png">

After:
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/2358483/190969929-e5e28fac-da79-4392-b20d-894eddd3f933.png">
