### PR TITLE
Use official MLflow release

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
 cookiecutter>=2.1.0
 pytest
 pytest-black
-git+https://github.com/mlflow/mlflow.git#egg=mlflow[pipelines]
+mlflow[pipelines]>=1.29.0

--- a/{{cookiecutter.project_name}}/requirements.txt
+++ b/{{cookiecutter.project_name}}/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/mlflow/mlflow.git#egg=mlflow[pipelines]
+mlflow[pipelines]>=1.29.0
 numpy>=1.23.0
 pandas>=1.4.3
 scikit-learn>=1.1.1


### PR DESCRIPTION
Use official MLflow release, instead of MLflow from master, in our tests/production jobs now that the bugfixes in MLflow 1.29.0 are released