### PR TITLE
[ML-26724]Update recipe and profiles to use new format

### DIFF
--- a/local_extensions.py
+++ b/local_extensions.py
@@ -19,6 +19,8 @@ def generate_doc_link(path, cloud):
 
     :return: documentation links for the specified cloud
     """
+    if cloud == "azure" and path == "repos/set-up-git-integration.html":
+        path = "repos/repos-setup"
     baseUrl = AZURE_DOC_BASE if cloud == "azure" else AWS_DOC_BASE
     newDocsPath = path.replace(".html", "") if cloud == "azure" else path
     return f"{baseUrl}/{newDocsPath}"

--- a/{{cookiecutter.project_name}}/profiles/databricks-dev.yaml
+++ b/{{cookiecutter.project_name}}/profiles/databricks-dev.yaml
@@ -2,23 +2,26 @@
 experiment:
   name: "/{{cookiecutter.experiment_base_name}}-dev"
 
-# TODO: update this field to point to the path to your model training dataset on the Databricks workspace
-# you use for development
-INGEST_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
-# TODO: Specify the format of the dataset
-# See https://github.com/mlflow/mlp-regression-template/blob/35f6f32c7a89dc655fbcfcf731cc1da4685a8ebb/pipeline.yaml#L15-L32
-# for details on supported formats
-INGEST_DATA_FORMAT: spark_sql
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+model_registry:
+  # Specify the MLflow registered model name under which to register model versions
+  model_name: "{{cookiecutter.model_name}}-dev"
+
 # Override the default train / validation / test dataset split ratios
 SPLIT_RATIOS: [0.75, 0.125, 0.125]
 
-# TODO: Specify the name/path of the input table for batch inference in your dev workspace here
-INGEST_SCORING_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
-# TODO: Specify the format of the dataset
-INGEST_SCORING_DATA_FORMAT: spark_sql
-# TODO: Specify the name of the output table for batch inference in your dev workspace here
-SCORED_OUTPUT_DATA_LOCATION: "{{cookiecutter.project_name}}_batch_scoring"
-# Specify the output format of the batch scoring predict step
-SCORED_OUTPUT_DATA_FORMAT: table
-# Specify the MLflow registered model name under which to register model versions
-MODEL_NAME: "{{cookiecutter.model_name}}-dev"
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
+  using: spark_sql
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
+  using: spark_sql
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step
+  using: table
+  location: "{{cookiecutter.project_name}}_batch_scoring"

--- a/{{cookiecutter.project_name}}/profiles/databricks-dev.yaml
+++ b/{{cookiecutter.project_name}}/profiles/databricks-dev.yaml
@@ -15,11 +15,13 @@ INGEST_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
   using: spark_sql
   sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 INGEST_SCORING_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
   using: spark_sql
   sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 PREDICT_OUTPUT_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step

--- a/{{cookiecutter.project_name}}/profiles/databricks-prod.yaml
+++ b/{{cookiecutter.project_name}}/profiles/databricks-prod.yaml
@@ -16,11 +16,13 @@ INGEST_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
   using: spark_sql
   sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 INGEST_SCORING_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
   using: spark_sql
   sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 PREDICT_OUTPUT_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step

--- a/{{cookiecutter.project_name}}/profiles/databricks-prod.yaml
+++ b/{{cookiecutter.project_name}}/profiles/databricks-prod.yaml
@@ -1,24 +1,28 @@
 experiment:
   name: {% raw -%}{{ ('../databricks-config/output/prod.json' | from_json){% endraw %}["{{cookiecutter.project_name}}_experiment_name"]["value"]{% raw-%}}}{% endraw %}
 
-# TODO: update this field to point to the path to your model training dataset on your production Databricks workspace
-INGEST_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
-# TODO: Specify the format of the dataset
-# See https://github.com/mlflow/mlp-regression-template/blob/35f6f32c7a89dc655fbcfcf731cc1da4685a8ebb/pipeline.yaml#L15-L32
-# for details on supported formats
-INGEST_DATA_FORMAT: spark_sql
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+model_registry:
+  # The MLflow registered model name under which to register model versions
+  # In prod, we log to the model provisioned through ML configs under databricks-config
+  # See databricks-config/README.md for details
+  model_name: {% raw -%}{{ ('../databricks-config/output/prod.json' | from_json){% endraw %}["{{cookiecutter.project_name}}_model_name"]["value"]{% raw %}}}{% endraw %}
+
 # Override the default train / validation / test dataset split ratios
 SPLIT_RATIOS: [0.75, 0.125, 0.125]
 
-# TODO: Specify the name/path of the input table for batch inference in your prod workspace here
-INGEST_SCORING_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
-# TODO: Specify the format of the dataset
-INGEST_SCORING_DATA_FORMAT: spark_sql
-# TODO: Specify the name of the output table for batch inference in your prod workspace here
-SCORED_OUTPUT_DATA_LOCATION: "{{cookiecutter.project_name}}_batch_scoring"
-# Specify the output format of the batch scoring predict step
-SCORED_OUTPUT_DATA_FORMAT: table
-# The MLflow registered model name under which to register model versions
-# In prod, we log to the model provisioned through ML configs under databricks-config
-# See databricks-config/README.md for details
-MODEL_NAME: {% raw -%}{{ ('../databricks-config/output/prod.json' | from_json){% endraw %}["{{cookiecutter.project_name}}_model_name"]["value"]{% raw %}}}{% endraw %}
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
+  using: spark_sql
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
+  using: spark_sql
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step
+  using: table
+  location: "{{cookiecutter.project_name}}_batch_scoring"

--- a/{{cookiecutter.project_name}}/profiles/databricks-staging.yaml
+++ b/{{cookiecutter.project_name}}/profiles/databricks-staging.yaml
@@ -16,11 +16,13 @@ INGEST_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
   using: spark_sql
   sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 INGEST_SCORING_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
   using: spark_sql
   sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 PREDICT_OUTPUT_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step

--- a/{{cookiecutter.project_name}}/profiles/databricks-staging.yaml
+++ b/{{cookiecutter.project_name}}/profiles/databricks-staging.yaml
@@ -1,26 +1,28 @@
 experiment:
   name: {% raw -%}{{ ('../databricks-config/output/staging.json' | from_json){% endraw %}["{{cookiecutter.project_name}}_experiment_name"]["value"]{% raw-%}}}{% endraw %}
 
-# TODO: update this field to point to the path to your model training dataset on your staging Databricks workspace,
-# to be used in the staging instance of your ML jobs. For example, you may want to create a downsampled version of your
-# full production dataset and specify its path here.
-INGEST_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
-# TODO: Specify the format of the dataset
-# See https://github.com/mlflow/mlp-regression-template/blob/35f6f32c7a89dc655fbcfcf731cc1da4685a8ebb/pipeline.yaml#L15-L32
-# for details on supported formats
-INGEST_DATA_FORMAT: spark_sql
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+model_registry:
+  # The MLflow registered model name under which to register model versions
+  # In prod, we log to the model provisioned through ML configs under databricks-config
+  # See databricks-config/README.md for details
+  model_name: {% raw -%}{{ ('../databricks-config/output/staging.json' | from_json){% endraw %}["{{cookiecutter.project_name}}_model_name"]["value"]{% raw-%}}}{% endraw %}
+
 # Override the default train / validation / test dataset split ratios
 SPLIT_RATIOS: [0.75, 0.125, 0.125]
 
-# TODO: Specify the name/path of the input table for batch inference in your staging workspace here
-INGEST_SCORING_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
-# TODO: Specify the format of the dataset
-INGEST_SCORING_DATA_FORMAT: spark_sql
-# TODO: Specify the name of the output table for batch inference in your prod workspace here
-SCORED_OUTPUT_DATA_LOCATION: "{{cookiecutter.project_name}}_batch_scoring"
-# Specify the output format of the batch scoring predict step
-SCORED_OUTPUT_DATA_FORMAT: table
-# The MLflow registered model name under which to register model versions
-# In prod, we log to the model provisioned through ML configs under databricks-config
-# See databricks-config/README.md for details
-MODEL_NAME: {% raw -%}{{ ('../databricks-config/output/staging.json' | from_json){% endraw %}["{{cookiecutter.project_name}}_model_name"]["value"]{% raw-%}}}{% endraw %}
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
+  using: spark_sql
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
+  using: spark_sql
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step
+  using: table
+  location: "{{cookiecutter.project_name}}_batch_scoring"

--- a/{{cookiecutter.project_name}}/profiles/databricks-test.yaml
+++ b/{{cookiecutter.project_name}}/profiles/databricks-test.yaml
@@ -15,11 +15,13 @@ INGEST_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
   using: spark_sql
   sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 INGEST_SCORING_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
   using: spark_sql
   sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 PREDICT_OUTPUT_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step

--- a/{{cookiecutter.project_name}}/profiles/databricks-test.yaml
+++ b/{{cookiecutter.project_name}}/profiles/databricks-test.yaml
@@ -1,24 +1,27 @@
 experiment:
   name: "{{cookiecutter.mlflow_experiment_parent_dir}}/{{cookiecutter.experiment_base_name}}-test"
 
-# TODO: update this field to point to the path to your model training dataset on your staging Databricks workspace,
-# to be used in tests. For example, you may want to create a downsampled version of your full production dataset
-# and specify its path here.
-INGEST_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
-# TODO: Specify the format of the dataset
-# See https://github.com/mlflow/mlp-regression-template/blob/35f6f32c7a89dc655fbcfcf731cc1da4685a8ebb/pipeline.yaml#L15-L32
-# for details on supported formats
-INGEST_DATA_FORMAT: spark_sql
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+model_registry:
+  # Specifies the name of the Registered Model to use when registering a trained model to
+  # the MLflow Model Registry
+  model_name: "{{cookiecutter.model_name}}-test"
+
 # Override the default train / validation / test dataset split ratios
 SPLIT_RATIOS: [0.75, 0.125, 0.125]
 
-# TODO: Specify the name/path of the input table for batch inference tests here
-INGEST_SCORING_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
-# TODO: Specify the format of the dataset
-INGEST_SCORING_DATA_FORMAT: spark_sql
-# TODO: Specify the name of the output table for batch inference in tests here
-SCORED_OUTPUT_DATA_LOCATION: "{{cookiecutter.project_name}}_batch_scoring_test"
-# Specify the output format of the batch scoring predict step
-SCORED_OUTPUT_DATA_FORMAT: table
-# Specify the MLflow registered model name under which to register model versions
-MODEL_NAME: "{{cookiecutter.model_name}}-test"
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
+  using: spark_sql
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
+  using: spark_sql
+  sql: SELECT * FROM delta.`dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled`
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step
+  using: table
+  location: "{{cookiecutter.project_name}}_batch_scoring_test"

--- a/{{cookiecutter.project_name}}/profiles/local.yaml
+++ b/{{cookiecutter.project_name}}/profiles/local.yaml
@@ -3,22 +3,25 @@ experiment:
   tracking_uri: "sqlite:///mlruns.db"
   artifact_location: "./mlruns"
 
-# TODO: update this field to point to a local filesystem path containing e.g. a sample of your model training
-# dataset for local development.
-INGEST_DATA_LOCATION: "./data/sample.parquet"
-# TODO: Specify the format of the dataset
-# See https://github.com/mlflow/mlp-regression-template/blob/35f6f32c7a89dc655fbcfcf731cc1da4685a8ebb/pipeline.yaml#L15-L32
-# for details on supported formats
-INGEST_DATA_FORMAT: parquet
-# TODO: update this field to point to a local filesystem path containing e.g. a sample of your input dataset
-# for batch inference
-INGEST_SCORING_DATA_LOCATION: "./data/sample.parquet"
-# Use a larger section of the TLC Trip Record Dataset for the batch scoring feature
-# Specify the format of the dataset
-INGEST_SCORING_DATA_FORMAT: parquet
+model_registry:
+  # Specifies the name of the Registered Model to use when registering a trained model to
+  # the MLflow Model Registry
+  model_name: {%raw-%}{{{%endraw%}MODEL_NAME|default('{{cookiecutter.project_name}}_model'){%raw-%}}}{%endraw%}
+
 # Override the default train / validation / test dataset split ratios
 SPLIT_RATIOS: [0.80, 0.10, 0.10]
-# Specify the output location of the batch scoring predict step
-SCORED_OUTPUT_DATA_LOCATION: "./data/sample_output.parquet"
-# Specify the output format of the batch scoring predict step
-SCORED_OUTPUT_DATA_FORMAT: parquet
+
+INGEST_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
+  using: parquet
+  location: "./data/sample.parquet"
+
+INGEST_SCORING_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
+  using: parquet
+  location: "./data/sample.parquet"
+
+PREDICT_OUTPUT_CONFIG:
+  # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step
+  using: parquet
+  location: "./data/sample_output.parquet"

--- a/{{cookiecutter.project_name}}/profiles/local.yaml
+++ b/{{cookiecutter.project_name}}/profiles/local.yaml
@@ -15,11 +15,13 @@ INGEST_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#ingest-step
   using: parquet
   location: "./data/sample.parquet"
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 INGEST_SCORING_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#batch-scoring
   using: parquet
   location: "./data/sample.parquet"
+  custom_loader_method: steps.ingest.load_file_as_dataframe
 
 PREDICT_OUTPUT_CONFIG:
   # For different options please read: https://github.com/mlflow/mlp-regression-template#predict-step

--- a/{{cookiecutter.project_name}}/recipe.yaml
+++ b/{{cookiecutter.project_name}}/recipe.yaml
@@ -11,34 +11,13 @@
 # files are properly formatted.
 
 recipe: "regression/v1"
-# Specifies the dataset to use for model development
-data:
-  # Dataset locations on the local filesystem are supported, as well as HTTP(S) URLs and
-  # any other remote locations resolvable by MLflow, such as those listed in
-  # https://mlflow.org/docs/latest/tracking.html#artifact-stores
-  location: {%raw-%}{{INGEST_DATA_LOCATION}}{%endraw%}
-  # Beyond `parquet` datasets, the `spark_sql` and `delta` formats are also natively supported for
-  # use with Spark
-  format: {%raw-%}{{INGEST_DATA_FORMAT|default('parquet')}}{%endraw%}
-  # Datasets with other formats, including `csv`, can be used by implementing and
-  # specifying a `custom_loader_method`
-  custom_loader_method: steps.ingest.load_file_as_dataframe
-  # If the `spark_sql` `format` is specified, the `sql` entry is used to specify a SparkSQL
-  # statement that identifies the dataset to use
-  sql: SELECT * FROM delta.`{%raw-%}{{INGEST_DATA_LOCATION}}`{%endraw%}
-  # If the `delta` `format` is specified, you can also configure the Delta table `version` to read
-  # or the `timestamp` at which to read data
-  # version: 2
-  # timestamp: 2022-06-01T00:00:00.000Z
-# specify the dataset to use for batch scoring.  All params serve the same function as in `data`
-data_scoring:
-  location: {%raw-%}{{INGEST_SCORING_DATA_LOCATION}}{%endraw%}
-  format: {%raw-%}{{INGEST_SCORING_DATA_FORMAT|default('parquet')}}{%endraw%}
-  custom_loader_method: steps.ingest.load_file_as_dataframe
-  sql: SELECT * FROM delta.`{%raw-%}{{INGEST_SCORING_DATA_LOCATION}}`{%endraw%}
 # Specifies the name of the column containing targets / labels for model training and evaluation
 target_col: "fare_amount"
+# Sets the primary metric to use to evaluate model performance. This primary metric is used
+# to sort MLflow Runs corresponding to the recipe in the MLflow Tracking UI
+primary_metric: "root_mean_squared_error"
 steps:
+  ingest: {%raw-%}{{INGEST_CONFIG}}{%endraw%}
   split:
     # Train/validation/test split ratios
     split_ratios: {%raw-%}{{SPLIT_RATIOS|default([0.75, 0.125, 0.125])}}{%endraw%}
@@ -62,28 +41,19 @@ steps:
       - metric: weighted_mean_squared_error
         threshold: 20
   register:
-    # Specifies the name of the Registered Model to use when registering a trained model to
-    # the MLflow Model Registry
-    model_name: {%raw-%}{{{%endraw%}MODEL_NAME|default('{{cookiecutter.project_name}}_model'){%raw-%}}}{%endraw%}
     # Indicates whether or not a model that fails to meet performance thresholds should still
     # be registered to the MLflow Model Registry
     allow_non_validated_model: false
+  ingest_scoring: {%raw-%}{{INGEST_SCORING_CONFIG}}{%endraw%}
   predict:
-    # Specifically define the model URI to use in batch scoring here or use the latest model
-    # registered from the training DAG
+    output: {%raw-%}{{PREDICT_OUTPUT_CONFIG}}{%endraw%}
     # model_uri: "models/model.pkl"
-    # Specify the output path of the scored data from predict
-    output_location: {%raw-%}{{SCORED_OUTPUT_DATA_LOCATION}}{%endraw%}
-    # Specify the output format of the scored data from predict
-    output_format: {%raw-%}{{SCORED_OUTPUT_DATA_FORMAT|default('parquet')}}{%endraw%}
-metrics:
-  # Defines custom performance metrics to compute during model training and evaluation
-  # TODO: specify custom metrics for model training here, or remove them if not applicable
-  custom:
+# Defines custom performance metrics to compute during model training and evaluation
+# TODO: specify custom metrics for model training here, or remove them if not applicable
+custom_metrics:
     - name: weighted_mean_squared_error
       # Specifies the name of the function in `steps/custom_metrics.py` to use to compute the metric
       function: weighted_mean_squared_error
       greater_is_better: False
-  # Sets the primary metric to use to evaluate model performance. This primary metric is used
-  # to sort MLflow Runs corresponding to the recipe in the MLflow Tracking UI
-  primary: "root_mean_squared_error"
+
+

--- a/{{cookiecutter.project_name}}/recipe.yaml
+++ b/{{cookiecutter.project_name}}/recipe.yaml
@@ -55,5 +55,3 @@ custom_metrics:
       # Specifies the name of the function in `steps/custom_metrics.py` to use to compute the metric
       function: weighted_mean_squared_error
       greater_is_better: False
-
-

--- a/{{cookiecutter.project_name}}/steps/custom_metrics.py
+++ b/{{cookiecutter.project_name}}/steps/custom_metrics.py
@@ -22,7 +22,7 @@ from sklearn.metrics import mean_squared_error
 def weighted_mean_squared_error(
     eval_df: DataFrame,
     builtin_metrics: Dict[str, int],  # pylint: disable=unused-argument
-) -> Dict[str, int]:
+) -> int:
     """
     Computes the weighted mean squared error (MSE) metric.
 
@@ -40,10 +40,8 @@ def weighted_mean_squared_error(
              the value is the scalar metric value. Note that custom metric functions can return
              dictionaries with multiple metric entries as well.
     """
-    return {
-        "weighted_mean_squared_error": mean_squared_error(
-            eval_df["prediction"],
-            eval_df["target"],
-            sample_weight=1 / eval_df["prediction"].values,
-        )
-    }
+    return mean_squared_error(
+        eval_df["prediction"],
+        eval_df["target"],
+        sample_weight=1 / eval_df["prediction"].values,
+    )


### PR DESCRIPTION
Previous PR of renaming mlflow pipelines to recipes: https://github.com/databricks/mlops-stack/pull/18

## This PR
Update the profiles and recipe to new format.

Also fix Azure doc path. 
"https://learn.microsoft.com/en-us/azure/databricks/repos/set-up-git-integration" is not found.
Update to "https://learn.microsoft.com/en-us/azure/databricks/repos/repos-setup"

## run tests
<img width="1544" alt="Screen Shot 2022-11-07 at 3 21 26 PM" src="https://user-images.githubusercontent.com/12734110/200437697-6845497b-1a02-4020-aea8-6de59cfd4f12.png">
<img width="1547" alt="Screen Shot 2022-11-07 at 3 22 30 PM" src="https://user-images.githubusercontent.com/12734110/200437699-c4b1a7db-ec96-4db3-9b0d-2f879801e95d.png">

## Test on dogfooding server
Generate project, submit to git and test on dogfooding server. All work fine.
link https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#notebook/877499343543488/command/877499343543502

