### PR TITLE
Tag clusters used for ADO CI/CD workflows

### DIFF
--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
@@ -101,7 +101,8 @@ jobs:
                     "spark.databricks.cluster.profile": "singleNode"
                     },
                   "custom_tags": {
-                    "ResourceClass": "SingleNode"
+                    "ResourceClass": "SingleNode",
+                    "clusterSource": "mlops-stack/0.0"
                     }
                   }
                 }


### PR DESCRIPTION
Tag clusters used for Azure DevOps CI/CD workflows as originating from MLOps stacks, to help categorize clusters/attribute cost back to MLOps stacks workloads