### PR TITLE
Azure DevOps fixes

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -6,7 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.2.7
       - uses: actions/setup-python@v2
         with:
           python-version: 3.9

--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -7,8 +7,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: 1.2.7
       - uses: actions/setup-python@v2
         with:
           python-version: 3.9

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To create a new project, run:
 This will prompt for parameters for project initialization. Some of these parameters are required to get started:
  * ``project_name``: name of the current project
  * ``cloud``: Cloud provider you use with Databricks (AWS, Azure, or GCP)
- * ``cicd_platform`` : CI/CD platform of choice (azureDevOpsServices or gitHub)
+ * ``cicd_platform`` : CI/CD platform of choice (GitHub Actions or Azure DevOps)
 
 Others must be correctly specified for CI/CD to work, and so can be left at their default values until you're
 ready to productionize a model. We recommend specifying any known parameters upfront (e.g. if you know

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
@@ -89,7 +89,7 @@ stages:
         ARM_TENANT_ID: $(stagingAzureSpTenantId)
         ARM_CLIENT_ID: $(stagingAzureSpApplicationId)
         ARM_CLIENT_SECRET: $(stagingAzureSpClientSecret)
-        DATABRICKS_HOST: $(STAGING_DATABRICKS_HOST)
+        DATABRICKS_HOST: $(stagingDatabricksHost)
 
   - job: ProdTerraformCI
     displayName: 'Continuous integration tests for prod Terraform scripts'
@@ -153,7 +153,7 @@ stages:
         ARM_TENANT_ID: $(prodAzureSpTenantId)
         ARM_CLIENT_ID: $(prodAzureSpApplicationId)
         ARM_CLIENT_SECRET: $(prodAzureSpClientSecret)
-        DATABRICKS_HOST: $(PROD_DATABRICKS_HOST)
+        DATABRICKS_HOST: $(prodDatabricksHost)
 
 # Run Terraform CD stage after successfully merging to {{cookiecutter.default_branch}}
 - stage: TerraformCD
@@ -226,7 +226,7 @@ stages:
         ARM_TENANT_ID: $(stagingAzureSpTenantId)
         ARM_CLIENT_ID: $(stagingAzureSpApplicationId)
         ARM_CLIENT_SECRET: $(stagingAzureSpClientSecret)
-        DATABRICKS_HOST: $(STAGING_DATABRICKS_HOST)
+        DATABRICKS_HOST: $(stagingDatabricksHost)
 
     - script: |
         terraform apply -auto-approve \
@@ -237,7 +237,7 @@ stages:
         ARM_TENANT_ID: $(stagingAzureSpTenantId)
         ARM_CLIENT_ID: $(stagingAzureSpApplicationId)
         ARM_CLIENT_SECRET: $(stagingAzureSpClientSecret)
-        DATABRICKS_HOST: $(STAGING_DATABRICKS_HOST)
+        DATABRICKS_HOST: $(stagingDatabricksHost)
 
     - script: |
         TERRAFORM_OUTPUT=$(terraform -chdir=staging output -json)
@@ -334,7 +334,7 @@ stages:
         ARM_TENANT_ID: $(prodAzureSpTenantId)
         ARM_CLIENT_ID: $(prodAzureSpApplicationId)
         ARM_CLIENT_SECRET: $(prodAzureSpClientSecret)
-        DATABRICKS_HOST: $(PROD_DATABRICKS_HOST)
+        DATABRICKS_HOST: $(prodDatabricksHost)
 
     - script: |
         terraform apply -auto-approve \
@@ -345,7 +345,7 @@ stages:
         ARM_TENANT_ID: $(prodAzureSpTenantId)
         ARM_CLIENT_ID: $(prodAzureSpApplicationId)
         ARM_CLIENT_SECRET: $(prodAzureSpClientSecret)
-        DATABRICKS_HOST: $(PROD_DATABRICKS_HOST)
+        DATABRICKS_HOST: $(prodDatabricksHost)
 
     - script: |
         TERRAFORM_OUTPUT=$(terraform -chdir=prod output -json)

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
@@ -19,6 +19,7 @@ stages:
 # Run Terraform CI stage on pull requests to {{cookiecutter.default_branch}}
 - stage: TerraformCI
   displayName: 'Terraform Tests for {{cookiecutter.project_name}}'
+  # Trigger TerraformCI stage on PR against the default branch, and not on pushes to other branches
   condition: |
     and(
       not(eq(variables['Build.Reason'], 'IndividualCI')),
@@ -158,6 +159,7 @@ stages:
 # Run Terraform CD stage after successfully merging to {{cookiecutter.default_branch}}
 - stage: TerraformCD
   displayName: 'Terraform Deployment for {{cookiecutter.project_name}}'
+  # Trigger TerraformCD after successfully pushing to the default branch, not on initial PR to the default branch
   condition: |
     and(
       eq(variables['Build.SourceBranch'], 'refs/heads/{{cookiecutter.default_branch}}'),

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
@@ -47,10 +47,10 @@ stages:
 
     - script: |
         set -e
-        STAGING_AZURE_SP_TENANT_ID=$(STAGING_AZURE_SP_TENANT_ID)
-        STAGING_AZURE_SP_APPLICATION_ID=$(STAGING_AZURE_SP_APPLICATION_ID)
-        STAGING_AZURE_SP_CLIENT_SECRET=$(STAGING_AZURE_SP_CLIENT_SECRET)
-        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$STAGING_AZURE_SP_TENANT_ID" "$STAGING_AZURE_SP_APPLICATION_ID" "$STAGING_AZURE_SP_CLIENT_SECRET")
+        stagingAzureSpTenantId=$(stagingAzureSpTenantId)
+        STAGING-AZURE_SP_APPLICATION_ID=$(stagingAzureSpApplicationId)
+        stagingAzureSpClientSecret=$(stagingAzureSpClientSecret)
+        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$stagingAzureSpTenantId" "$stagingAzureSpApplicationId" "$stagingAzureSpClientSecret")
         echo "##vso[task.setvariable variable=DATABRICKS_TOKEN;issecret=true]${DATABRICKS_TOKEN}"
       displayName: 'Configure AAD auth'
 
@@ -71,9 +71,9 @@ stages:
       displayName: 'Terraform Init'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(STAGING_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(stagingAzureSpTenantId)
+        ARM_CLIENT_ID: $(stagingAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(stagingAzureSpClientSecret)
 
     - script: |
         terraform validate -no-color
@@ -86,9 +86,9 @@ stages:
       displayName: 'Terraform Plan'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(STAGING_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(stagingAzureSpTenantId)
+        ARM_CLIENT_ID: $(stagingAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(stagingAzureSpClientSecret)
         DATABRICKS_HOST: $(STAGING_DATABRICKS_HOST)
 
   - job: ProdTerraformCI
@@ -112,10 +112,10 @@ stages:
 
     - script: |
         set -e
-        PROD_AZURE_SP_TENANT_ID=$(PROD_AZURE_SP_TENANT_ID)
-        PROD_AZURE_SP_APPLICATION_ID=$(PROD_AZURE_SP_APPLICATION_ID)
-        PROD_AZURE_SP_CLIENT_SECRET=$(PROD_AZURE_SP_CLIENT_SECRET)
-        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$PROD_AZURE_SP_TENANT_ID" "$PROD_AZURE_SP_APPLICATION_ID" "$PROD_AZURE_SP_CLIENT_SECRET")
+        prodAzureSpTenantId=$(prodAzureSpTenantId)
+        prodAzureSpApplicationId=$(prodAzureSpApplicationId)
+        prodAzureSpClientSecret=$(prodAzureSpClientSecret)
+        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$prodAzureSpTenantId" "$prodAzureSpApplicationId" "$prodAzureSpClientSecret")
         echo "##vso[task.setvariable variable=DATABRICKS_TOKEN;issecret=true]${DATABRICKS_TOKEN}"
       displayName: 'Configure AAD auth'
 
@@ -135,9 +135,9 @@ stages:
       displayName: 'Terraform Init'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(PROD_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(prodAzureSpTenantId)
+        ARM_CLIENT_ID: $(prodAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(prodAzureSpClientSecret)
 
     - script: |
         terraform validate -no-color
@@ -150,9 +150,9 @@ stages:
       displayName: 'Terraform Plan'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(PROD_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(prodAzureSpTenantId)
+        ARM_CLIENT_ID: $(prodAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(prodAzureSpClientSecret)
         DATABRICKS_HOST: $(PROD_DATABRICKS_HOST)
 
 # Run Terraform CD stage after successfully merging to {{cookiecutter.default_branch}}
@@ -185,10 +185,10 @@ stages:
 
     - script: |
         set -e
-        STAGING_AZURE_SP_TENANT_ID=$(STAGING_AZURE_SP_TENANT_ID)
-        STAGING_AZURE_SP_APPLICATION_ID=$(STAGING_AZURE_SP_APPLICATION_ID)
-        STAGING_AZURE_SP_CLIENT_SECRET=$(STAGING_AZURE_SP_CLIENT_SECRET)
-        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$STAGING_AZURE_SP_TENANT_ID" "$STAGING_AZURE_SP_APPLICATION_ID" "$STAGING_AZURE_SP_CLIENT_SECRET")
+        stagingAzureSpTenantId=$(stagingAzureSpTenantId)
+        stagingAzureSpApplicationId=$(stagingAzureSpApplicationId)
+        stagingAzureSpClientSecret=$(stagingAzureSpClientSecret)
+        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$stagingAzureSpTenantId" "$stagingAzureSpApplicationId" "$stagingAzureSpClientSecret")
         echo "##vso[task.setvariable variable=DATABRICKS_TOKEN;issecret=true]${DATABRICKS_TOKEN}"
       displayName: 'Configure AAD auth'
 
@@ -208,9 +208,9 @@ stages:
       displayName: 'Terraform Init'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(STAGING_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(stagingAzureSpTenantId)
+        ARM_CLIENT_ID: $(stagingAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(stagingAzureSpClientSecret)
 
     - script: |
         terraform validate
@@ -223,9 +223,9 @@ stages:
       displayName: 'Terraform Plan'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(STAGING_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(stagingAzureSpTenantId)
+        ARM_CLIENT_ID: $(stagingAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(stagingAzureSpClientSecret)
         DATABRICKS_HOST: $(STAGING_DATABRICKS_HOST)
 
     - script: |
@@ -234,9 +234,9 @@ stages:
       displayName: 'Terraform Apply'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(STAGING_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(stagingAzureSpTenantId)
+        ARM_CLIENT_ID: $(stagingAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(stagingAzureSpClientSecret)
         DATABRICKS_HOST: $(STAGING_DATABRICKS_HOST)
 
     - script: |
@@ -246,9 +246,9 @@ stages:
       displayName: 'Terraform Output'
       workingDirectory: $(working-directory)
       env:
-        ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(STAGING_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(stagingAzureSpTenantId)
+        ARM_CLIENT_ID: $(stagingAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(stagingAzureSpClientSecret)
 
     - script: |
         ORIGINAL_BRANCH='$(Build.SourceBranch)'
@@ -293,10 +293,10 @@ stages:
 
     - script: |
         set -e
-        PROD_AZURE_SP_TENANT_ID=$(PROD_AZURE_SP_TENANT_ID)
-        PROD_AZURE_SP_APPLICATION_ID=$(PROD_AZURE_SP_APPLICATION_ID)
-        PROD_AZURE_SP_CLIENT_SECRET=$(PROD_AZURE_SP_CLIENT_SECRET)
-        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$PROD_AZURE_SP_TENANT_ID" "$PROD_AZURE_SP_APPLICATION_ID" "$PROD_AZURE_SP_CLIENT_SECRET")
+        prodAzureSpTenantId=$(prodAzureSpTenantId)
+        prodAzureSpApplicationId=$(prodAzureSpApplicationId)
+        prodAzureSpClientSecret=$(prodAzureSpClientSecret)
+        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$prodAzureSpTenantId" "$prodAzureSpApplicationId" "$prodAzureSpClientSecret")
         echo "##vso[task.setvariable variable=DATABRICKS_TOKEN;issecret=true]${DATABRICKS_TOKEN}"
       displayName: 'Configure AAD auth'
 
@@ -316,9 +316,9 @@ stages:
       displayName: 'Terraform Init'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(PROD_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(prodAzureSpTenantId)
+        ARM_CLIENT_ID: $(prodAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(prodAzureSpClientSecret)
 
     - script: |
         terraform validate
@@ -331,9 +331,9 @@ stages:
       displayName: 'Terraform Plan'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(PROD_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(prodAzureSpTenantId)
+        ARM_CLIENT_ID: $(prodAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(prodAzureSpClientSecret)
         DATABRICKS_HOST: $(PROD_DATABRICKS_HOST)
 
     - script: |
@@ -342,9 +342,9 @@ stages:
       displayName: 'Terraform Apply'
       workingDirectory: $(working-directory)/$(environment)
       env:
-        ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(PROD_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(prodAzureSpTenantId)
+        ARM_CLIENT_ID: $(prodAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(prodAzureSpClientSecret)
         DATABRICKS_HOST: $(PROD_DATABRICKS_HOST)
 
     - script: |
@@ -354,9 +354,9 @@ stages:
       displayName: 'Terraform Output'
       workingDirectory: $(working-directory)
       env:
-        ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
-        ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
-        ARM_CLIENT_SECRET: $(PROD_AZURE_SP_CLIENT_SECRET)
+        ARM_TENANT_ID: $(prodAzureSpTenantId)
+        ARM_CLIENT_ID: $(prodAzureSpApplicationId)
+        ARM_CLIENT_SECRET: $(prodAzureSpClientSecret)
 
     - script: |
         ORIGINAL_BRANCH='$(Build.SourceBranch)'

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
@@ -13,6 +13,7 @@ trigger:
 
 variables:
   working-directory: ./databricks-config
+  ARM_SUBSCRIPTION_ID: $(armSubscriptionId)
 
 stages:
 

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
@@ -21,6 +21,7 @@ stages:
   displayName: 'Terraform Tests for {{cookiecutter.project_name}}'
   condition: |
     and(
+      not(eq(variables['Build.Reason'], 'IndividualCI')),
       eq(variables['Build.Reason'], 'PullRequest'),
       eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/{{cookiecutter.default_branch}}')
     )
@@ -159,8 +160,8 @@ stages:
   displayName: 'Terraform Deployment for {{cookiecutter.project_name}}'
   condition: |
     and(
-      succeeded(),
-      eq(variables['Build.Reason'], 'PullRequest')
+      eq(variables['Build.SourceBranch'], 'refs/heads/{{cookiecutter.default_branch}}'),
+      not(eq(variables['Build.Reason'], 'PullRequest'))
     )
 
   jobs:

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/terraform-cicd.yml
@@ -48,7 +48,7 @@ stages:
     - script: |
         set -e
         stagingAzureSpTenantId=$(stagingAzureSpTenantId)
-        STAGING-AZURE_SP_APPLICATION_ID=$(stagingAzureSpApplicationId)
+        stagingAzureSpApplicationId=$(stagingAzureSpApplicationId)
         stagingAzureSpClientSecret=$(stagingAzureSpClientSecret)
         DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$stagingAzureSpTenantId" "$stagingAzureSpApplicationId" "$stagingAzureSpClientSecret")
         echo "##vso[task.setvariable variable=DATABRICKS_TOKEN;issecret=true]${DATABRICKS_TOKEN}"

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
@@ -121,7 +121,7 @@ jobs:
               }
           }'
       env:
-        DATABRICKS_HOST: $(STAGING_DATABRICKS_HOST)
+        DATABRICKS_HOST: $(stagingDatabricksHost)
         DATABRICKS_TOKEN: $(DATABRICKS_TOKEN)
       displayName: 'Trigger integration test'
 

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
@@ -68,10 +68,10 @@ jobs:
 
     - script: |
         set -e
-        STAGING_AZURE_SP_TENANT_ID=$(STAGING_AZURE_SP_TENANT_ID)
-        STAGING_AZURE_SP_APPLICATION_ID=$(STAGING_AZURE_SP_APPLICATION_ID)
-        STAGING_AZURE_SP_CLIENT_SECRET=$(STAGING_AZURE_SP_CLIENT_SECRET)
-        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$STAGING_AZURE_SP_TENANT_ID" "$STAGING_AZURE_SP_APPLICATION_ID" "$STAGING_AZURE_SP_CLIENT_SECRET")
+        stagingAzureSpTenantId=$(stagingAzureSpTenantId)
+        stagingAzureSpApplicationId=$(stagingAzureSpApplicationId)
+        stagingAzureSpClientSecret=$(stagingAzureSpClientSecret)
+        DATABRICKS_TOKEN=$(.azure/devops-pipelines/scripts/generate-aad-token.sh "$stagingAzureSpTenantId" "$stagingAzureSpApplicationId" "$stagingAzureSpClientSecret")
         echo "##vso[task.setvariable variable=DATABRICKS_TOKEN;issecret=true]${DATABRICKS_TOKEN}"
       displayName: 'Configure AAD auth'
 

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
@@ -14,7 +14,7 @@ jobs:
       and(
         not(eq(variables['Build.Reason'], 'IndividualCI')),
         eq(variables['Build.Reason'], 'PullRequest'),
-        eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/main')
+        eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/{{cookiecutter.default_branch}}')
       )
     pool:
       vmImage: 'ubuntu-latest'

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
@@ -1,5 +1,5 @@
 # Run CI on pull requests to {{cookiecutter.default_branch}}
-pr:
+trigger:
   branches:
     include:
       - {{cookiecutter.default_branch}}
@@ -10,6 +10,12 @@ pr:
 jobs:
   - job: UnitTests
     displayName: 'Unit Tests'
+    condition: |
+      and(
+        not(eq(variables['Build.Reason'], 'IndividualCI')),
+        eq(variables['Build.Reason'], 'PullRequest'),
+        eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/main')
+      )
     pool:
       vmImage: 'ubuntu-latest'
 
@@ -40,6 +46,7 @@ jobs:
   - job: IntegrationTests
     displayName: 'Integration Tests'
     dependsOn: UnitTests
+    condition: succeeded()
     pool:
       vmImage: 'ubuntu-latest'
 

--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-model-prod.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-model-prod.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.PROD_AZURE_SP_TENANT_ID }} ${{ secrets.PROD_AZURE_SP_APPLICATION_ID }} ${{ secrets.PROD_AZURE_SP_CLIENT_SECRET }}{% endraw %}
+        {% raw %}run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.prodAzureSpTenantId }} ${{ secrets.prodAzureSpApplicationId }} ${{ secrets.prodAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - name: Deploy model
         env:

--- a/{{cookiecutter.project_name}}/.github/workflows/deploy-model-staging.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy-model-staging.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.STAGING_AZURE_SP_TENANT_ID }} ${{ secrets.STAGING_AZURE_SP_APPLICATION_ID }} ${{ secrets.STAGING_AZURE_SP_CLIENT_SECRET }}{% endraw %}
+        {% raw %}run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - name: Deploy model
         env:

--- a/{{cookiecutter.project_name}}/.github/workflows/run-tests-fs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/run-tests-fs.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.STAGING_AZURE_SP_TENANT_ID }} ${{ secrets.STAGING_AZURE_SP_APPLICATION_ID }} ${{ secrets.STAGING_AZURE_SP_CLIENT_SECRET }}{% endraw %}
+        {% raw %}run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       # This step populates a JSON Databricks job payload that will be submitted as an integration test run.
       # It currently builds a one-off multi-task job that contains feature engineering tasks to populate Feature

--- a/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.STAGING_AZURE_SP_TENANT_ID }} ${{ secrets.STAGING_AZURE_SP_APPLICATION_ID }} ${{ secrets.STAGING_AZURE_SP_CLIENT_SECRET }}{% endraw %}
+        {% raw %}run: ./.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - name: Train model
         uses: databricks/run-notebook@v0

--- a/{{cookiecutter.project_name}}/.github/workflows/terraform-cd.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/terraform-cd.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.STAGING_AZURE_SP_TENANT_ID }} ${{ secrets.STAGING_AZURE_SP_APPLICATION_ID }} ${{ secrets.STAGING_AZURE_SP_CLIENT_SECRET }}{% endraw %}
+        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - uses: hashicorp/setup-terraform@v1
       - name: Terraform fmt
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v3
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.PROD_AZURE_SP_TENANT_ID }} ${{ secrets.PROD_AZURE_SP_APPLICATION_ID }} ${{ secrets.PROD_AZURE_SP_CLIENT_SECRET }}{% endraw %}
+        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.prodAzureSpTenantId }} ${{ secrets.prodAzureSpApplicationId }} ${{ secrets.prodAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - uses: hashicorp/setup-terraform@v1
       - name: Terraform fmt

--- a/{{cookiecutter.project_name}}/.github/workflows/terraform-ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/terraform-ci.yml
@@ -28,7 +28,7 @@ jobs:
           ref: {% raw %}${{ github.event.pull_request.head.sha || github.sha }}{% endraw %}
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.STAGING_AZURE_SP_TENANT_ID }} ${{ secrets.STAGING_AZURE_SP_APPLICATION_ID }} ${{ secrets.STAGING_AZURE_SP_CLIENT_SECRET }}{% endraw %}
+        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - uses: hashicorp/setup-terraform@v1
       - name: Terraform fmt
@@ -112,7 +112,7 @@ jobs:
           ref: {% raw %}${{ github.event.pull_request.head.sha || github.sha }}{% endraw %}
       {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.PROD_AZURE_SP_TENANT_ID }} ${{ secrets.PROD_AZURE_SP_APPLICATION_ID }} ${{ secrets.PROD_AZURE_SP_CLIENT_SECRET }}{% endraw %}
+        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.prodAzureSpTenantId }} ${{ secrets.prodAzureSpApplicationId }} ${{ secrets.prodAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - uses: hashicorp/setup-terraform@v1
       - name: Terraform fmt

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -18,18 +18,19 @@ to other CI/CD providers by running the same shell commands, with a few caveats:
   to instead hit the appropriate REST API endpoint for triggering model deployment CD for your CI/CD provider.
 
 {% elif cookiecutter.cicd_platform == "azureDevOpsServices" -%}
-The scripts set up CI/CD with Azure DevOps. During initial set up we do the following:
+The bootstrap steps use Terraform to set up the following in an automated manner:
 1. Create an Azure Blob Storage container for storing ML resource config (job, MLflow experiment, etc) state for the
-   current ML project
+   current ML project.
 2. Create another Azure Blob Storage container for storing the state of CI/CD principals provisioned for the current
-   ML project
-3. Write credentials for accessing the container in (1) to a file
+   ML project.
+3. Write credentials for accessing the container in (1) to a file.
 4. Create Databricks service principals configured for CI/CD, write their credentials to a file, and store their
    state in the Azure Blob Storage container created in (2).
-5. Create two Azure DevOps Pipelines:
+5. Create the two following Azure DevOps Pipelines along with required variable group:
     * `testing_ci` - Unit tests and integration tests triggered upon PR to the {{cookiecutter.default_branch}} branch.
     * `terraform_cicd` - Continuous integration for Terraform triggered upon a PR to {{cookiecutter.default_branch}} and changes to `databricks-config`, 
                          followed by continuous deployment of changes upon successfully merging into {{cookiecutter.default_branch}}.
+6. Create build validation policies defining requirements when PRs are submitted to the default branch of your repository.        
 {% endif -%}
       
 ## Prerequisites
@@ -203,27 +204,36 @@ python .mlops-setup-scripts/cicd/bootstrap.py \
 {%- endif %}
 ```
 
-Take care to run the Terraform bootstrap script before the CI/CD bootstrap script. This will:
+Take care to run the Terraform bootstrap script before the CI/CD bootstrap script. 
+
+The first Terraform bootstrap script will:
 
 {% if cookiecutter.cloud == "azure" %}
 1. Create an Azure Blob Storage container for storing ML resource config (job, MLflow experiment, etc) state for the
    current ML project
 2. Create another Azure Blob Storage container for storing the state of CI/CD principals provisioned for the current
    ML project
+   
+The second CI/CD bootstrap script will:
 3. Write credentials for accessing the container in (1) to a file
 4. Create Databricks service principals configured for CI/CD, write their credentials to a file, and store their
    state in the Azure Blob Storage container created in (2).
 {% if cookiecutter.cicd_platform == "azureDevOpsServices" %}
-5. Create two Azure DevOps Pipelines:
+5. Create the two following Azure DevOps Pipelines along with required variable group:
     * `testing_ci` - Unit tests and integration tests triggered upon PR to the {{cookiecutter.default_branch}} branch.
     * `terraform_cicd` - Continuous integration for Terraform triggered upon a PR to {{cookiecutter.default_branch}} and changes to `databricks-config`, 
                          followed by continuous deployment of changes upon successfully merging into {{cookiecutter.default_branch}}.
+6. Create build validation policies defining requirements when PRs are submitted to the default branch of your repository.        
 {% endif %}
+   
 {% elif cookiecutter.cloud == "aws" %}
 1. Create an AWS S3 bucket and DynamoDB table for storing ML resource config (job, MLflow experiment, etc) state for the
    current ML project
 2. Create another AWS S3 bucket and DynamoDB table for storing the state of CI/CD principals provisioned for the current
    ML project. 
+   
+The second CI/CD bootstrap script will:
+
 3. Write credentials for accessing the S3 bucket and Dynamo DB table in (1) to a file.
 4. Create Databricks service principals configured for CI/CD, write their credentials to a file, and store their
    state in the S3 bucket and DynamoDB table created in (2). 

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -250,7 +250,7 @@ Store each of the generated secrets in the output JSON files as
 [GitHub Actions Encrypted Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository),
 where the JSON key
 {% if cookiecutter.cloud == "azure" -%}
-(e.g. `PROD_AZURE_SP_APPLICATION_ID`)
+(e.g. `prodAzureSpApplicationId`)
 {% elif cookiecutter.cloud == "aws" -%}
 (e.g. `PROD_WORKSPACE_TOKEN`)
 {% endif -%} 

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -145,11 +145,12 @@ be sure to generate a token with "Repo" scope. If you have SSO enabled with your
 This token is used to fetch ML code from the current repo to run on Databricks for CI/CD (e.g. to check out code from a PR branch and run it
 during CI/CD). You can generate a PAT token for Azure DevOps by following the steps described [here](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows).
 Ensure your PAT (at a minimum) has the following permissions:
-- **Variable Groups**: Read, Create, & Manage
 - **Build**: Read & execute
+- **Code**: Read, write & manage
 - **Project and Team**: Read
 - **Token Administration**: Read & manage
 - **Tokens**: Read & manage
+- **Variable Groups**: Read, Create, & Manage
 - **Work Items**: Read
 
 ### Update permissions for the build service

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -36,9 +36,12 @@ The scripts set up CI/CD with Azure DevOps. During initial set up we do the foll
 
 ### Install CLIs
 * Install the [Terraform CLI](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+  * Requirement: `terraform >=1.2.7`
 * Install the [Databricks CLI](https://github.com/databricks/databricks-cli): ``pip install databricks-cli``
+    * Requirement: `databricks-cli >= 0.17`
 {% if cookiecutter.cloud == "azure" -%}
 * Install Azure CLI: ``pip install azure-cli``
+    * Requirement: `azure-cli >= 2.39.0`
 {% elif cookiecutter.cloud == "aws" -%}
 * Install AWS CLI: ``pip install awscli``
 {%- endif %}

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -159,10 +159,12 @@ Terraform deploy stage of our pipeline. Within this pipeline `git` commands are 
 To enable this workflow you must update the permissions of our build service. Within your **Project Settings**, select **Repostiories**.
 Go to the name of your repository and select **Security**. For the user `{{cookiecutter.project_name}} Build Service (<your-username>)` grant the following:
 - **Bypass policies when completing pull requests**: Allow
-- **Create branch:** Allow
+- **Bypass policies when pushing**: Allow
 - **Contribute:** Allow
-- **Read:** Allow
+- **Create branch:** Allow
 - **Create tag:** Allow
+- **Read:** Allow
+
 {% endif -%}
 
 

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -27,9 +27,9 @@ The scripts set up CI/CD with Azure DevOps. During initial set up we do the foll
 4. Create Databricks service principals configured for CI/CD, write their credentials to a file, and store their
    state in the Azure Blob Storage container created in (2).
 5. Create two Azure DevOps Pipelines:
-    * `testing_ci` - Unit tests and integration tests triggered upon PR to the main branch.
-    * `terraform_cicd` - Continuous integration for Terraform triggered upon a PR to main and changes to `databricks-config`, 
-                         followed by continuous deployment of changes upon successfully merging into main.
+    * `testing_ci` - Unit tests and integration tests triggered upon PR to the {{cookiecutter.default_branch}} branch.
+    * `terraform_cicd` - Continuous integration for Terraform triggered upon a PR to {{cookiecutter.default_branch}} and changes to `databricks-config`, 
+                         followed by continuous deployment of changes upon successfully merging into {{cookiecutter.default_branch}}.
 {% endif -%}
       
 ## Prerequisites
@@ -151,9 +151,12 @@ Ensure your PAT (at a minimum) has the following permissions:
 - **Tokens**: Read & manage
 - **Work Items**: Read
 
-### Grant version control permissions to CI/CD
-The provided CI/CD workflows attempt to run `git` commands to commit and modify files. To ensure the workflows can work properly, [grant version control permissions](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/git-commands?view=azure-devops&tabs=yaml#grant-version-control-permissions-to-the-build-service) within your hosted Azure DevOps repo.
-The user `{{cookiecutter.project_name}} Build Service (<your-username>)` should be granted the following:
+### Update permissions for the build service
+In our CI/CD workflow, upon successfully merging a PR with changes to `databricks-config/**` the CD step will trigger the
+Terraform deploy stage of our pipeline. As part of this pipeline we run `git` commands to commit and modify Terraform output files. 
+To enable this workflow we must update the permissions of our build service. Within your **Project Settings**, select **Repostiories**.
+Go to the name of your repository and select **Security**. For the user `{{cookiecutter.project_name}} Build Service (<your-username>)` grant the following:
+- **Bypass policies when completing pull requests**: Allow
 - **Create branch:** Allow
 - **Contribute:** Allow
 - **Read:** Allow
@@ -212,9 +215,9 @@ Take care to run the Terraform bootstrap script before the CI/CD bootstrap scrip
    state in the Azure Blob Storage container created in (2).
 {% if cookiecutter.cicd_platform == "azureDevOpsServices" %}
 5. Create two Azure DevOps Pipelines:
-    * `testing_ci` - Unit tests and integration tests triggered upon PR to the main branch.
-    * `terraform_cicd` - Continuous integration for Terraform triggered upon a PR to main and changes to `databricks-config`, 
-                         followed by continuous deployment of changes upon successfully merging into main.
+    * `testing_ci` - Unit tests and integration tests triggered upon PR to the {{cookiecutter.default_branch}} branch.
+    * `terraform_cicd` - Continuous integration for Terraform triggered upon a PR to {{cookiecutter.default_branch}} and changes to `databricks-config`, 
+                         followed by continuous deployment of changes upon successfully merging into {{cookiecutter.default_branch}}.
 {% endif %}
 {% elif cookiecutter.cloud == "aws" %}
 1. Create an AWS S3 bucket and DynamoDB table for storing ML resource config (job, MLflow experiment, etc) state for the

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -218,6 +218,7 @@ The first Terraform bootstrap script will:
    ML project
    
 The second CI/CD bootstrap script will:
+
 3. Write credentials for accessing the container in (1) to a file
 4. Create Databricks service principals configured for CI/CD, write their credentials to a file, and store their
    state in the Azure Blob Storage container created in (2).

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -154,8 +154,8 @@ Ensure your PAT (at a minimum) has the following permissions:
 
 ### Update permissions for the build service
 In our CI/CD workflow, upon successfully merging a PR with changes to `databricks-config/**` the CD step will trigger the
-Terraform deploy stage of our pipeline. As part of this pipeline we run `git` commands to commit and modify Terraform output files. 
-To enable this workflow we must update the permissions of our build service. Within your **Project Settings**, select **Repostiories**.
+Terraform deploy stage of our pipeline. Within this pipeline `git` commands are run to commit and modify Terraform output files. 
+To enable this workflow you must update the permissions of our build service. Within your **Project Settings**, select **Repostiories**.
 Go to the name of your repository and select **Security**. For the user `{{cookiecutter.project_name}} Build Service (<your-username>)` grant the following:
 - **Bypass policies when completing pull requests**: Allow
 - **Create branch:** Allow

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -143,6 +143,13 @@ be sure to generate a token with "Repo" scope. If you have SSO enabled with your
 {% elif cookiecutter.cicd_platform == "azureDevOpsServices" -%}
 This token is used to fetch ML code from the current repo to run on Databricks for CI/CD (e.g. to check out code from a PR branch and run it
 during CI/CD). You can generate a PAT token for Azure DevOps by following the steps described [here](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows).
+Ensure your PAT (at a minimum) has the following permissions:
+- **Variable Groups**: Read, Create, & Manage
+- **Build**: Read & execute
+- **Project and Team**: Read
+- **Token Administration**: Read & manage
+- **Tokens**: Read & manage
+- **Work Items**: Read
 
 ### Grant version control permissions to CI/CD
 The provided CI/CD workflows attempt to run `git` commands to commit and modify files. To ensure the workflows can work properly, [grant version control permissions](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/git-commands?view=azure-devops&tabs=yaml#grant-version-control-permissions-to-the-build-service) within your hosted Azure DevOps repo.

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
@@ -3,10 +3,6 @@
 //  - Require that SP created in main-azure are Enterprise Applications
 //  - Role definitions of SPs are updated to allow access to the storage backend
 //  - Variable groups created to allow secrets generated to be passed through into CICD scripts
-data "azuredevops_project" "project_name" {
-  name = var.azure_devops_project_name
-}
-
 data "azurerm_subscription" "current" {
 }
 

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
@@ -153,7 +153,7 @@ resource "azuredevops_branch_policy_build_validation" "testing-ci-build-validati
     display_name        = "Testing CI build validation policy"
     build_definition_id = azuredevops_build_definition.testing-ci.id
     valid_duration      = 720
-    filename_patterns = ["*", "!/databricks-config/**"]
+    filename_patterns   = ["*", "!/databricks-config/**"]
 
     scope {
       repository_id  = data.azuredevops_git_repository.repo.id
@@ -177,7 +177,7 @@ resource "azuredevops_branch_policy_build_validation" "terraform-cicd-build-vali
     display_name        = "Terraform CICD build validation policy"
     build_definition_id = azuredevops_build_definition.terraform-cicd.id
     valid_duration      = 720
-    filename_patterns = ["/databricks-config/**"]
+    filename_patterns   = ["/databricks-config/**"]
 
     scope {
       repository_id  = data.azuredevops_git_repository.repo.id

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
@@ -51,20 +51,20 @@ resource "azuredevops_variable_group" "cicd_vg" {
   }
 
   variable {
-    name         = "STAGING_AZURE_SP_APPLICATION_ID"
+    name         = "stagingAzureSpApplicationId"
     secret_value = module.azure_create_sp.staging_service_principal_application_id
     is_secret    = true
   }
 
   variable {
-    name         = "STAGING_AZURE_SP_CLIENT_SECRET"
+    name         = "stagingAzureSpClientSecret"
     secret_value = module.azure_create_sp.staging_service_principal_client_secret
     is_secret    = true
   }
 
   variable {
     # NOTE: assumes staging and prod Databricks workspaces are under the same Azure tenant
-    name  = "STAGING_AZURE_SP_TENANT_ID"
+    name  = "stagingAzureSpTenantId"
     value = var.azure_tenant_id
   }
 
@@ -74,19 +74,19 @@ resource "azuredevops_variable_group" "cicd_vg" {
   }
 
   variable {
-    name         = "PROD_AZURE_SP_APPLICATION_ID"
+    name         = "prodAzureSpApplicationId"
     secret_value = module.azure_create_sp.prod_service_principal_application_id
     is_secret    = true
   }
 
   variable {
-    name         = "PROD_AZURE_SP_CLIENT_SECRET"
+    name         = "prodAzureSpClientSecret"
     secret_value = module.azure_create_sp.prod_service_principal_client_secret
     is_secret    = true
   }
 
   variable {
-    name = "PROD_AZURE_SP_TENANT_ID"
+    name = "prodAzureSpTenantId"
     // NOTE: assumes staging and prod Databricks workspaces are under the same Azure tenant
     value = var.azure_tenant_id
   }

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
@@ -46,7 +46,7 @@ resource "azuredevops_variable_group" "cicd_vg" {
   allow_access = true
 
   variable {
-    name  = "STAGING_DATABRICKS_HOST"
+    name  = "stagingDatabricksHost"
     value = "{{cookiecutter.databricks_staging_workspace_host}}"
   }
 
@@ -69,7 +69,7 @@ resource "azuredevops_variable_group" "cicd_vg" {
   }
 
   variable {
-    name  = "PROD_DATABRICKS_HOST"
+    name  = "prodDatabricksHost"
     value = "{{cookiecutter.databricks_prod_workspace_host}}"
   }
 
@@ -92,13 +92,13 @@ resource "azuredevops_variable_group" "cicd_vg" {
   }
 
   variable {
-    name      = "ARM_ACCESS_KEY"
+    name      = "armAccessKey"
     value     = var.arm_access_key
     is_secret = true
   }
 
   variable {
-    name  = "ARM_SUBSCRIPTION_ID"
+    name  = "armSubscriptionId"
     value = data.azurerm_subscription.current.subscription_id
   }
 

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
@@ -153,6 +153,7 @@ resource "azuredevops_branch_policy_build_validation" "testing-ci-build-validati
     display_name        = "Testing CI build validation policy"
     build_definition_id = azuredevops_build_definition.testing-ci.id
     valid_duration      = 720
+    filename_patterns = ["*", "!/databricks-config/**"]
 
     scope {
       repository_id  = data.azuredevops_git_repository.repo.id
@@ -176,6 +177,7 @@ resource "azuredevops_branch_policy_build_validation" "terraform-cicd-build-vali
     display_name        = "Terraform CICD build validation policy"
     build_definition_id = azuredevops_build_definition.terraform-cicd.id
     valid_duration      = 720
+    filename_patterns = ["/databricks-config/**"]
 
     scope {
       repository_id  = data.azuredevops_git_repository.repo.id

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/main-azure.tf
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/main-azure.tf
@@ -101,32 +101,32 @@ resource "azuread_service_principal" "prod_service_principal" {
 {% elif cookiecutter.cicd_platform == "azureDevOpsServices" -%}
 // Output values
 {%- endif %}
-output "STAGING_AZURE_SP_APPLICATION_ID" {
+output "stagingAzureSpApplicationId" {
   value     = module.azure_create_sp.staging_service_principal_application_id
   sensitive = true
 }
 
-output "STAGING_AZURE_SP_CLIENT_SECRET" {
+output "stagingAzureSpClientSecret" {
   value     = module.azure_create_sp.staging_service_principal_client_secret
   sensitive = true
 }
 
-output "STAGING_AZURE_SP_TENANT_ID" {
+output "stagingAzureSpTenantId" {
   value     = var.azure_tenant_id
   sensitive = true
 }
 
-output "PROD_AZURE_SP_APPLICATION_ID" {
+output "prodAzureSpApplicationId" {
   value     = module.azure_create_sp.prod_service_principal_application_id
   sensitive = true
 }
 
-output "PROD_AZURE_SP_CLIENT_SECRET" {
+output "prodAzureSpClientSecret" {
   value     = module.azure_create_sp.prod_service_principal_client_secret
   sensitive = true
 }
 
-output "PROD_AZURE_SP_TENANT_ID" {
+output "prodAzureSpTenantId" {
   value     = var.azure_tenant_id
   sensitive = true
 }


### PR DESCRIPTION
### Summary of Azure DevOps fixes/updates:

- Fix triggers for CI/CD pipelines. Previously, pipelines were triggered on pushes to any branch (`IndividualCI`). Now CI pipelines are only triggered on PR to default branch. Terraform deploy now triggers when PR has been successfully merged to default branch (and only on changes to `/databricks/config/**`) [[ML-27221]](https://databricks.atlassian.net/browse/ML-27221)
  - Added required permissions for build service to enable this. We set up build validation on the default branch in terraform cicd boostrap. In order for the Terraform deploy step to be able to write to the default branch after successfully merging a PR to main, we must give the build service permissions to override this branch policy. [[ML-27222]](https://databricks.atlassian.net/browse/ML-27222)
- Version requirements for terraform, databricks-cli, azure-cli [[ML-27220]](https://databricks.atlassian.net/browse/ML-27220)
- List explicit PAT permissions required [[ML-27219]](https://databricks.atlassian.net/browse/ML-27219)
- Change Terraform output variables to camelCase in order to make them compatible with Azure Key Vault [[ML-27218]](https://databricks.atlassian.net/browse/ML-27218)