### PR TITLE
Change Azure DevOp pipelines to be run automatically on a repo level

### DIFF
--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
@@ -41,7 +41,7 @@ resource "azurerm_role_assignment" "prod_role_assignment" {
 // Create variable group to be used by Azure DevOps Pipelines
 resource "azuredevops_variable_group" "cicd_vg" {
   project_id   = data.azuredevops_project.project.project_id
-  name         = "CICD Variable Group"
+  name         = "CICD Variable Group [${data.azuredevops_git_repository.repo.name}]"
   description  = "Variable group for CICD pipelines"
   allow_access = true
 
@@ -106,7 +106,7 @@ resource "azuredevops_variable_group" "cicd_vg" {
 
 resource "azuredevops_build_definition" "testing-ci" {
   project_id = data.azuredevops_project.project.project_id
-  name       = "testing_ci"
+  name       = "testing_ci_${data.azuredevops_git_repository.repo.name}"
 
   ci_trigger {
     use_yaml = true
@@ -124,7 +124,7 @@ resource "azuredevops_build_definition" "testing-ci" {
 
 resource "azuredevops_build_definition" "terraform-cicd" {
   project_id = data.azuredevops_project.project.project_id
-  name       = "terraform_cicd"
+  name       = "terraform_cicd_${data.azuredevops_git_repository.repo.name}"
 
   ci_trigger {
     use_yaml = true
@@ -150,7 +150,7 @@ resource "azuredevops_branch_policy_build_validation" "testing-ci-build-validati
   blocking = true
 
   settings {
-    display_name        = "Testing CI build validation policy"
+    display_name        = "Testing CI build validation policy [${data.azuredevops_git_repository.repo.name}]"
     build_definition_id = azuredevops_build_definition.testing-ci.id
     valid_duration      = 720
     filename_patterns   = ["*", "!/databricks-config/**"]
@@ -159,10 +159,6 @@ resource "azuredevops_branch_policy_build_validation" "testing-ci-build-validati
       repository_id  = data.azuredevops_git_repository.repo.id
       repository_ref = data.azuredevops_git_repository.repo.default_branch
       match_type     = "Exact"
-    }
-
-    scope {
-      match_type = "DefaultBranch"
     }
   }
 }
@@ -174,7 +170,7 @@ resource "azuredevops_branch_policy_build_validation" "terraform-cicd-build-vali
   blocking = true
 
   settings {
-    display_name        = "Terraform CICD build validation policy"
+    display_name        = "Terraform CICD build validation policy [${data.azuredevops_git_repository.repo.name}]"
     build_definition_id = azuredevops_build_definition.terraform-cicd.id
     valid_duration      = 720
     filename_patterns   = ["/databricks-config/**"]
@@ -183,10 +179,6 @@ resource "azuredevops_branch_policy_build_validation" "terraform-cicd-build-vali
       repository_id  = data.azuredevops_git_repository.repo.id
       repository_ref = data.azuredevops_git_repository.repo.default_branch
       match_type     = "Exact"
-    }
-
-    scope {
-      match_type = "DefaultBranch"
     }
   }
 }

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/cicd/azure-devops.tf
@@ -41,7 +41,7 @@ resource "azurerm_role_assignment" "prod_role_assignment" {
 // Create variable group to be used by Azure DevOps Pipelines
 resource "azuredevops_variable_group" "cicd_vg" {
   project_id   = data.azuredevops_project.project.project_id
-  name         = "CICD Variable Group [${data.azuredevops_git_repository.repo.name}]"
+  name         = "CICD Variable Group (${data.azuredevops_git_repository.repo.name})"
   description  = "Variable group for CICD pipelines"
   allow_access = true
 
@@ -106,7 +106,7 @@ resource "azuredevops_variable_group" "cicd_vg" {
 
 resource "azuredevops_build_definition" "testing-ci" {
   project_id = data.azuredevops_project.project.project_id
-  name       = "testing_ci_${data.azuredevops_git_repository.repo.name}"
+  name       = "Testing CI (${data.azuredevops_git_repository.repo.name})"
 
   ci_trigger {
     use_yaml = true
@@ -124,7 +124,7 @@ resource "azuredevops_build_definition" "testing-ci" {
 
 resource "azuredevops_build_definition" "terraform-cicd" {
   project_id = data.azuredevops_project.project.project_id
-  name       = "terraform_cicd_${data.azuredevops_git_repository.repo.name}"
+  name       = "Terraform CICD (${data.azuredevops_git_repository.repo.name})"
 
   ci_trigger {
     use_yaml = true
@@ -150,7 +150,7 @@ resource "azuredevops_branch_policy_build_validation" "testing-ci-build-validati
   blocking = true
 
   settings {
-    display_name        = "Testing CI build validation policy [${data.azuredevops_git_repository.repo.name}]"
+    display_name        = "Testing CI build validation policy (${data.azuredevops_git_repository.repo.name})"
     build_definition_id = azuredevops_build_definition.testing-ci.id
     valid_duration      = 720
     filename_patterns   = ["*", "!/databricks-config/**"]
@@ -170,7 +170,7 @@ resource "azuredevops_branch_policy_build_validation" "terraform-cicd-build-vali
   blocking = true
 
   settings {
-    display_name        = "Terraform CICD build validation policy [${data.azuredevops_git_repository.repo.name}]"
+    display_name        = "Terraform CICD build validation policy (${data.azuredevops_git_repository.repo.name})"
     build_definition_id = azuredevops_build_definition.terraform-cicd.id
     valid_duration      = 720
     filename_patterns   = ["/databricks-config/**"]


### PR DESCRIPTION
## Description

Before this PR, ADO pipelines created by MLOps Stacks for one repo in an ADO project would be run on pull requests against all other repos in the same ADO project. This PR isolates the ADO branch policies on a repo level. It also augments the names of provisioned things with the repo name for clarity.

## Testing

I created two MLOps Stack projects based off of this feature branch and ran through the bootstrap scripts for both of them as two repos in the same ADO project. This resulted in the following ADO pipelines:
<img width="1193" alt="Screen Shot 2022-12-12 at 3 28 40 PM" src="https://user-images.githubusercontent.com/66143562/207181653-1577d7f6-43a3-4e66-b2f0-42dc0bd963a9.png">

Then, I created one ML code PR and one Databricks Config PR for one of the repos. See below that only the ADO pipelines for that repo were triggered:

<img width="824" alt="Screen Shot 2022-12-12 at 3 29 49 PM" src="https://user-images.githubusercontent.com/66143562/207181772-cd113d35-de3e-4a58-8820-3fa067af5d51.png">

<img width="808" alt="Screen Shot 2022-12-12 at 3 30 13 PM" src="https://user-images.githubusercontent.com/66143562/207181828-772e1d45-558e-48f0-b1ad-30a4dd27b7bc.png">

