### PR TITLE
Azure DevOps doc fix

### DIFF
--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -157,7 +157,7 @@ Ensure your PAT (at a minimum) has the following permissions:
 In our CI/CD workflow, upon successfully merging a PR with changes to `databricks-config/**` the CD step will trigger the
 Terraform deploy stage of our pipeline. Within this pipeline `git` commands are run to commit and modify Terraform output files. 
 To enable this workflow you must update the permissions of our build service. Within your **Project Settings**, select **Repostiories**.
-Go to the name of your repository and select **Security**. For the user `<name-of-azure-devops-project> Build Service (<your-username>)` grant the following:
+Go to the name of your repository and select **Security**. For the user `<your-azure-devops-project-name> Build Service (<your-username>)` grant the following:
 - **Bypass policies when completing pull requests**: Allow
 - **Bypass policies when pushing**: Allow
 - **Contribute:** Allow

--- a/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.project_name}}/.mlops-setup-scripts/README.md
@@ -157,7 +157,7 @@ Ensure your PAT (at a minimum) has the following permissions:
 In our CI/CD workflow, upon successfully merging a PR with changes to `databricks-config/**` the CD step will trigger the
 Terraform deploy stage of our pipeline. Within this pipeline `git` commands are run to commit and modify Terraform output files. 
 To enable this workflow you must update the permissions of our build service. Within your **Project Settings**, select **Repostiories**.
-Go to the name of your repository and select **Security**. For the user `{{cookiecutter.project_name}} Build Service (<your-username>)` grant the following:
+Go to the name of your repository and select **Security**. For the user `<name-of-azure-devops-project> Build Service (<your-username>)` grant the following:
 - **Bypass policies when completing pull requests**: Allow
 - **Bypass policies when pushing**: Allow
 - **Contribute:** Allow


### PR DESCRIPTION
- Previously README stated to update the Build Service named `{{cookiecutter.project_name}} Build Service (<your-username>)`. This is only valid if the repo name in Azure DevOps is equivalent to the name of the Azure DevOps Project. 
- The Build Service which requires configuring will actually be labeled by the name of the Azure DevOps project i.e `<name-of-azure-devops-project> Build Service (<your-username>)`