### PR TITLE
[ML-28129] Add notebook for model validation and set up terraform job

### DIFF
--- a/{{cookiecutter.project_name}}/databricks-config/README.md
+++ b/{{cookiecutter.project_name}}/databricks-config/README.md
@@ -97,9 +97,9 @@ The model validation job is implemented in `notebooks/ModelValidation`. The mode
 
 To enable the model validation stack, resolve the TODOs in `notebooks/ModelValidation` to complete the model validation implementation.
 Then update `run_mode` in `staging/training-job.tf` and `prod/training-job.tf`. `run_mode` has three possible values:
-* `Disabled` : Do not run the model validation notebook.
-* `Dry Run`  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
-* `Enabled`  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing. 
+* `disabled` : Do not run the model validation notebook.
+* `dry_run`  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
+* `enabled`  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
 
 Once model validation is in enabled or dry run mode, the model validation result will be logged to the registered model version.
 ## Develop and test config changes

--- a/{{cookiecutter.project_name}}/databricks-config/README.md
+++ b/{{cookiecutter.project_name}}/databricks-config/README.md
@@ -89,19 +89,20 @@ principal corresponding to a particular environment has permissions to read the 
 
 ### Setting up model validation
 The model validation stack focuses on building a plug-and-play stack component for continuous deployment (CD) of models 
-in staging and prod. Its central purpose is to evaluate a registered model and validate its quality before moving it to 
-Production stage in model registry.
+in staging and prod.
+Its central purpose is to evaluate a registered model and validate its quality before deploying the model to Production/Staging.
 
 The model validation job is implemented in `notebooks/ModelValidation`. The model validation stack is defined in 
 `staging/training-job.tf` and `prod/training-job.tf`.
+As part of the workflow, model validation runs after training and before the deployment.
 
 To enable the model validation stack, resolve the TODOs in `notebooks/ModelValidation` to complete the model validation implementation.
-Then update `run_mode` in `staging/training-job.tf` and `prod/training-job.tf`. `run_mode` has three possible values:
+Then update `run_mode` in `staging/training-job.tf` and `prod/training-job.tf`. `run_mode` can be one of the three values:
 * `disabled` : Do not run the model validation notebook.
 * `dry_run`  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
 * `enabled`  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
 
-Once model validation is in enabled or dry run mode, the model validation result will be logged to the registered model version.
+Once model validation is in enabled or dry run mode, the model validation result will be logged to the description of the registered model version.
 ## Develop and test config changes
 To get started, open `staging/inference-job.tf`.  The file contains the ML resource definition of
 a batch inference job, like:

--- a/{{cookiecutter.project_name}}/databricks-config/README.md
+++ b/{{cookiecutter.project_name}}/databricks-config/README.md
@@ -87,6 +87,21 @@ principal corresponding to a particular environment has permissions to read the 
 * `SELECT` permission for the input table.
 * `MODIFY` permission for the output table if it pre-dates your job.
 
+### Setting up model validation
+The model validation stack focuses on building a plug-and-play stack component for continuous deployment (CD) of models 
+in staging and prod. Its central purpose is to evaluate a registered model and validate its quality before moving it to 
+Production stage in model registry.
+
+The model validation job is implemented in `notebooks/ModelValidation`. The model validation stack is defined in 
+`staging/training-job.tf` and `prod/training-job.tf`.
+
+To enable the model validation stack, resolve the TODOs in `notebooks/ModelValidation` to complete the model validation implementation.
+Then update `run_mode` in `staging/training-job.tf` and `prod/training-job.tf`. `run_mode` has three possible values:
+* `Disabled` : Do not run the model validation notebook.
+* `Dry Run`  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
+* `Enabled`  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing. 
+
+Once model validation is in enabled or dry run mode, the model validation result will be logged to the registered model version.
 ## Develop and test config changes
 To get started, open `staging/inference-job.tf`.  The file contains the ML resource definition of
 a batch inference job, like:

--- a/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
@@ -52,11 +52,11 @@ resource "databricks_job" "model_training_job" {
       base_parameters = {
         env = local.env
         # Run mode for model validation. Possible values are :
-        #   Disabled : Do not run the model validation notebook.
-        #   Dry Run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
-        #   Enabled  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
+        #   disabled : Do not run the model validation notebook.
+        #   dry_run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
+        #   enabled  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
         # Please complete the TODO sessions in notebooks/ModelValidation before enabling model validation
-        run_mode = "Disabled"
+        run_mode = "disabled"
       }
     }
 

--- a/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
@@ -63,7 +63,7 @@ resource "databricks_job" "model_training_job" {
     new_cluster {
       num_workers   = 3
       spark_version = "11.0.x-cpu-ml-scala2.12"
-      node_type_id  = "Standard_D3_v2"
+      node_type_id  = "{{cookiecutter.cloud_specific_node_type_id}}"
       custom_tags   = { "clusterSource" = "mlops-stack/0.0" }
     }
   }

--- a/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
@@ -42,9 +42,36 @@ resource "databricks_job" "model_training_job" {
   }
 
   task {
-    task_key = "TriggerModelDeploy"
+    task_key = "ModelValidation"
     depends_on {
       task_key = "Train"
+    }
+
+    notebook_task {
+      notebook_path = "notebooks/ModelValidation"
+      base_parameters = {
+        env = local.env
+        # Run mode for model validation. Possible values are :
+        #   Disabled : do not run the model validation notebook
+        #   Dry Run  : Run the model validation notebook. Fail the job if there are compling errors. Ignore failed model validation rules.
+        #   Enabled  : Run the model validation notebook. Return success only if all model validation rules are passing.
+        # Please complete the TODO sessions in notebooks/ModelValidation before enabling model validation
+        run_mode = "Disabled"
+      }
+    }
+
+    new_cluster {
+      num_workers   = 3
+      spark_version = "11.0.x-cpu-ml-scala2.12"
+      node_type_id  = "Standard_D3_v2"
+      custom_tags   = { "clusterSource" = "mlops-stack/0.0" }
+    }
+  }
+
+  task {
+    task_key = "TriggerModelDeploy"
+    depends_on {
+      task_key = "ModelValidation"
     }
 
     notebook_task {

--- a/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
@@ -52,9 +52,9 @@ resource "databricks_job" "model_training_job" {
       base_parameters = {
         env = local.env
         # Run mode for model validation. Possible values are :
-        #   Disabled : do not run the model validation notebook
-        #   Dry Run  : Run the model validation notebook. Fail the job if there are compling errors. Ignore failed model validation rules.
-        #   Enabled  : Run the model validation notebook. Return success only if all model validation rules are passing.
+        #   Disabled : Do not run the model validation notebook.
+        #   Dry Run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
+        #   Enabled  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
         # Please complete the TODO sessions in notebooks/ModelValidation before enabling model validation
         run_mode = "Disabled"
       }

--- a/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
@@ -59,7 +59,7 @@ resource "databricks_job" "model_training_job" {
     new_cluster {
       num_workers   = 3
       spark_version = "11.0.x-cpu-ml-scala2.12"
-      node_type_id  = "Standard_D3_v2"
+      node_type_id  = "{{cookiecutter.cloud_specific_node_type_id}}"
       custom_tags   = { "clusterSource" = "mlops-stack/0.0" }
     }
   }

--- a/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
@@ -48,9 +48,9 @@ resource "databricks_job" "model_training_job" {
       base_parameters = {
         env = local.env
         # Run mode for model validation. Possible values are :
-        #   Disabled : do not run the model validation notebook
-        #   Dry Run  : Run the model validation notebook. Fail the job if there are compling errors. Ignore failed model validation rules.
-        #   Enabled  : Run the model validation notebook. Return success only if all model validation rules are passing.
+        #   Disabled : Do not run the model validation notebook.
+        #   Dry Run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
+        #   Enabled  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
         # Please complete the TODO sessions in notebooks/ModelValidation before enabling model validation
         run_mode = "Disabled"
       }

--- a/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
@@ -48,11 +48,11 @@ resource "databricks_job" "model_training_job" {
       base_parameters = {
         env = local.env
         # Run mode for model validation. Possible values are :
-        #   Disabled : Do not run the model validation notebook.
-        #   Dry Run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
-        #   Enabled  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
+        #   disabled : Do not run the model validation notebook.
+        #   dry_run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
+        #   enabled  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
         # Please complete the TODO sessions in notebooks/ModelValidation before enabling model validation
-        run_mode = "Disabled"
+        run_mode = "disabled"
       }
     }
 

--- a/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
+++ b/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
@@ -14,14 +14,14 @@
 # * env (optional): Name of the environment the notebook is run in (staging, or prod). Defaults to "prod".
 #                   You can add environment-specific logic to this notebook based on the value of this parameter,
 #                   e.g. read validation data from different tables or data sources across environments.
-# * run_mode (optional): The model validation run mode. Default to Disabled. Possible values are Disabled, Dry Run, Enabled.
-#                       Disabled : do not run the model validation notebook
-#                       Dry Run  : Run the model validation notebook. Fail the job if there are compling errors. Ignore failed model validation rules.
-#                       Enabled  : Run the model validation notebook. Return success only if all model validation rules are passing.
+# * run_mode (optional): The model validation run mode. Defaults to Disabled. Possible values are Disabled, Dry Run, Enabled.
+#                       Disabled : Do not run the model validation notebook.
+#                       Dry Run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
+#                       Enabled  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
 #
 #
 #
-# For details on mlflow evalute API, see doc https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+# For details on mlflow evaluate API, see doc https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
 # For details and examples about performing model validation, see the Model Validation documentation https://mlflow.org/docs/latest/models.html#model-validation
 #
 ##################################################################################
@@ -107,7 +107,7 @@ mlflow.set_experiment(experiment_name)
 # exist for the model.
 # Baseline model is a requirement for relative change and absolute change validation rules.
 # TODO(required) : enable_baseline_comparison
-enable_baseline_comparison = True
+enable_baseline_comparison = False
 
 # model validation data input for staging or prod workspace. A Pandas DataFrame or Spark DataFrame, containing evaluation features and labels.
 # Please refer to data parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate

--- a/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
+++ b/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
@@ -14,10 +14,10 @@
 # * env (optional): Name of the environment the notebook is run in (staging, or prod). Defaults to "prod".
 #                   You can add environment-specific logic to this notebook based on the value of this parameter,
 #                   e.g. read validation data from different tables or data sources across environments.
-# * run_mode (optional): The model validation run mode. Defaults to Disabled. Possible values are Disabled, Dry Run, Enabled.
-#                       Disabled : Do not run the model validation notebook.
-#                       Dry Run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
-#                       Enabled  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
+# * run_mode (optional): The model validation run mode. Defaults to Disabled. Possible values are disabled, dry_run, enabled.
+#                       disabled : Do not run the model validation notebook.
+#                       dry_run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.
+#                       enabled  : Run the model validation notebook. Move model to Production stage only if all model validation rules are passing.
 #
 #
 #
@@ -38,7 +38,7 @@
 # COMMAND ----------
 
 dbutils.widgets.dropdown("env", "prod", ["staging", "prod"], "Environment Name")
-dbutils.widgets.dropdown("run_mode", "Disabled", ["Disabled", "Dry Run", "Enabled"], "Run Mode")
+dbutils.widgets.dropdown("run_mode", "disabled", ["disabled", "dry_run", "enabled"], "Run Mode")
 
 # COMMAND ----------
 
@@ -62,7 +62,7 @@ env = dbutils.widgets.get("env")
 _run_mode = dbutils.widgets.get("run_mode")
 if _run_mode.lower() == "disabled":
     dbutils.notebook.exit(0)
-dry_run = _run_mode.lower() == "dry run"
+dry_run = _run_mode.lower() == "dry_run"
 
 def get_model_type_from_recipe():
     recipe_config = get_recipe_config("../", f"databricks-{env}")

--- a/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
+++ b/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
@@ -162,17 +162,12 @@ def log_to_model_description(run, success):
     run_info = run.info
     run_link = "#mlflow/experiments/{0}/runs/{1}".format(run_info.experiment_id, run_info.run_id)
     description = client.get_model_version(model_name, model_version).description
-    if success:
-        status = "succeeded"
-        emoji = ":white_check_mark:"
-    else:
-        status = "failed"
-        emoji = ":x:"
+    status = "SUCCESS" if success else "FAILURE"
     if description != "":
         description += """
             ---
         """.replace(" ", "")
-    description += "### {0}Model validation {1}. Refer to [model validation run]({2}) for details\n".format(emoji, status, run_link)
+    description += "Model validation status: {0}\nValidation Details: {1}".format(status, run_link)
     client.update_model_version(
         name=model_name,
         version=model_version,

--- a/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
+++ b/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
@@ -1,0 +1,224 @@
+# Databricks notebook source
+##################################################################################
+# Model Validation Notebook
+##
+# This notebook uses mlflow model validation API to run mode validation after training and registering a model 
+# in model registry, before deploying it to Production stage.
+#
+# It runs as part of CD and by an automated model training job -> validation -> deployment job defined under ``databricks-config``
+#
+# Please finish the two cells with "TODO" comments before enabling the model validation.
+#
+# Parameters:
+#
+# * env (optional): Name of the environment the notebook is run in (staging, or prod). Defaults to "prod".
+#                   You can add environment-specific logic to this notebook based on the value of this parameter,
+#                   e.g. read validation data from different tables or data sources across environments.
+# * run_mode (optional): The model validation run mode. Default to Disabled. Possible values are Disabled, Dry Run, Enabled.
+#                       Disabled : do not run the model validation notebook
+#                       Dry Run  : Run the model validation notebook. Fail the job if there are compling errors. Ignore failed model validation rules.
+#                       Enabled  : Run the model validation notebook. Return success only if all model validation rules are passing.
+#
+#
+#
+# For details on mlflow evalute API, see doc https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+# For details and examples about performing model validation, see the Model Validation documentation https://mlflow.org/docs/latest/models.html#model-validation
+#
+##################################################################################
+
+# COMMAND ----------
+
+# MAGIC %load_ext autoreload
+# MAGIC %autoreload 2
+
+# COMMAND ----------
+
+# MAGIC %pip install -r ../requirements.txt
+
+# COMMAND ----------
+
+dbutils.widgets.dropdown("env", "prod", ["staging", "prod"], "Environment Name")
+dbutils.widgets.dropdown("run_mode", "Disabled", ["Disabled", "Dry Run", "Enabled"], "Run Mode")
+
+# COMMAND ----------
+
+import mlflow
+from mlflow.models import MetricThreshold, make_metric
+import pandas as pd
+import os
+import numpy as np
+import tempfile
+import json
+import traceback
+from mlflow.recipes.utils import (
+    get_recipe_config,
+    get_recipe_name,
+    get_recipe_root_path,
+)
+from mlflow.tracking.client import MlflowClient
+client = MlflowClient()
+
+env = dbutils.widgets.get("env")
+_run_mode = dbutils.widgets.get("run_mode")
+if _run_mode.lower() == "disabled":
+    dbutils.notebook.exit(0)
+dry_run = _run_mode.lower() == "dry run"
+
+def get_model_type_from_recipe():
+    recipe_config = get_recipe_config("../", f"databricks-{env}")
+    problem_type = recipe_config.get("recipe").split("/")[0]
+    if problem_type.lower() == "regression":
+        return "regressor"
+    elif problem_type.lower() == "classification":
+        return "classifier"
+    else:
+        raise Exception(f"Unsupported recipe {recipe_config}")
+
+def get_targets_from_recipe():
+    recipe_config = get_recipe_config("../", f"databricks-{env}")
+    return recipe_config.get("target_col")
+
+# set model evaluation parameters that can be inferred from the job
+model_uri = dbutils.jobs.taskValues.get("Train", "model_uri", debugValue="")
+model_name = dbutils.jobs.taskValues.get("Train", "model_name", debugValue="")
+model_version = dbutils.jobs.taskValues.get("Train", "model_version", debugValue="")
+
+baseline_model_uri = "models:/" + model_name + "/Production"
+evaluators = "default"
+assert env != "None", "env notebook parameter must be specified"
+assert model_uri != "", "model_uri notebook parameter must be specified"
+assert model_name != "", "model_name notebook parameter must be specified"
+assert model_version != "", "model_version notebook parameter must be specified"
+
+# set experiment
+with open("../databricks-config/output/prod.json", "r") as f:
+    experiment_name = json.load(f)["mlops-azure-cuj_experiment_name"]["value"]
+mlflow.set_experiment(experiment_name)
+
+# COMMAND ----------
+
+##################################################################################
+# TODO : Please fill in this cell with proper values for enable_baseline_comparison,
+#        data, targets, model_type, custom_metrics, validation_thresholds
+#        evaluator_config
+##################################################################################
+
+# Whether to load the current registered "Production" stage model as baseline. A version with "Production" stage must 
+# exist for the model.
+# Baseline model is a requirement for relative change and absolute change validation rules.
+# TODO(required) : enable_baseline_comparison
+enable_baseline_comparison = True
+
+# model validation data input for staging or prod workspace. A Pandas DataFrame or Spark DataFrame, containing evaluation features and labels.
+# Please refer to data parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+if env == "prod":
+    # TODO(required) : set data for prod workspace
+    data = None
+elif env == "staging":
+    # TODO(required) : set data for staging workspace
+    data = None
+else:
+    raise Exception("Unknown environment. Please select 'prod' or 'staging' as environment name")
+
+# The string name of a column from data that contains evaluation labels.
+# Call get_targets_from_recipe() to get targets from recipe configs if mlflow recipe is used. 
+# Please refer to targets parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+# TODO(required) : targets
+targets = get_targets_from_recipe()
+
+
+# A string describing the model type. The model type can be either "regressor" and "classifier".
+# Call get_model_type_from_recipe() to get model type from recipe configs if mlflow recipe is used. 
+# Please refer to model_type parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+# TODO(required) : model_type
+model_type = get_model_type_from_recipe()
+
+# Custom metrics to be included. Set it to None if custom metrics are not needed.
+# Please refer to custom_metrics parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+# TODO(optional) : define custom metric function as necessary
+# TODO(optional) : custom_metrics
+custom_metrics = []
+
+# Define model validation rules. Set it to None if validation rules are not needed.
+# Please refer to custom_metrics parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+# TODO(optional) : validation_thresholds
+validation_thresholds = {}
+
+# A dictionary of additional configurations to supply to the evaluator.
+# Please refer to evaluator_config parameter in mlflow.evaluate documentation https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate
+# TODO(optional) : evaluator_config
+evaluator_config = {}
+
+# COMMAND ----------
+
+client.get_model_version(model_name, model_version).description
+
+# COMMAND ----------
+
+eval_result = None
+err = None
+
+def log_to_model_description(run, success):
+    run_info = run.info
+    run_link = "#mlflow/experiments/{0}/runs/{1}".format(run_info.experiment_id, run_info.run_id)
+    description = client.get_model_version(model_name, model_version).description
+    if success:
+        status = "succeeded"
+        emoji = ":white_check_mark:"
+    else:
+        status = "failed"
+        emoji = ":x:"
+    if description != "":
+        description += """
+            ---
+        """.replace(" ", "")
+    description += "### {0}Model validation {1}. Refer to [model validation run]({2}) for details\n".format(emoji, status, run_link)
+    client.update_model_version(
+        name=model_name,
+        version=model_version,
+        description=description
+    )
+
+# run evaluate
+with mlflow.start_run() as run, tempfile.TemporaryDirectory() as tmp_dir:
+
+    validation_thresholds_file = os.path.join(tmp_dir, "validation_thresholds.txt")
+    with open(validation_thresholds_file, "w") as f:
+        if validation_thresholds:
+            for metric_name in validation_thresholds:
+                f.write("{0:30}  {1}\n".format(metric_name, str(validation_thresholds[metric_name])))
+    mlflow.log_artifact(validation_thresholds_file)
+
+    try:
+        eval_result = mlflow.evaluate(
+            model=model_uri,
+            data=data,
+            targets=targets,
+            model_type=model_type,
+            evaluators=evaluators,
+            validation_thresholds=validation_thresholds,
+            custom_metrics=custom_metrics,
+            baseline_model=None if not enable_baseline_comparison else baseline_model_uri,
+            evaluator_config=evaluator_config,
+        )
+        metrics_file = os.path.join(tmp_dir, "metrics.txt")
+        with open(metrics_file, "w") as f:
+            f.write("{0:30}  {1:30}  {2}\n".format("metric_name", "candidate", "baseline"))
+            for metric in eval_result.metrics:
+                candidate_metric_value = str(eval_result.metrics[metric])
+                baseline_metric_value = "N/A"
+                if metric in eval_result.baseline_model_metrics:
+                    mlflow.log_metric("baseline_"+metric, eval_result.baseline_model_metrics[metric])
+                    baseline_metric_value = str(eval_result.baseline_model_metrics[metric])
+                f.write("{0:30}  {1:30}  {2}\n".format(metric, candidate_metric_value, baseline_metric_value))
+        mlflow.log_artifact(metrics_file)
+        log_to_model_description(run, True)
+    except Exception as err:
+        log_to_model_description(run, False)
+        error_file = os.path.join(tmp_dir, "error.txt")
+        with open(error_file, "w") as f:
+            f.write("Validation failed : " + str(err) + "\n")
+            f.write(traceback.format_exc())
+        mlflow.log_artifact(error_file)
+        if not dry_run:
+            raise err

--- a/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
+++ b/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
@@ -106,7 +106,7 @@ mlflow.set_experiment(experiment_name)
 # Whether to load the current registered "Production" stage model as baseline. A version with "Production" stage must 
 # exist for the model.
 # Baseline model is a requirement for relative change and absolute change validation rules.
-# TODO(required) : enable_baseline_comparison
+# TODO(optional) : enable_baseline_comparison
 enable_baseline_comparison = False
 
 # model validation data input for staging or prod workspace. A Pandas DataFrame or Spark DataFrame, containing evaluation features and labels.

--- a/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
+++ b/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
@@ -92,7 +92,7 @@ assert model_version != "", "model_version notebook parameter must be specified"
 
 # set experiment
 with open("../databricks-config/output/prod.json", "r") as f:
-    experiment_name = json.load(f)["mlops-azure-cuj_experiment_name"]["value"]
+    experiment_name = json.load(f)["{{cookiecutter.project_name}}_experiment_name"]["value"]
 mlflow.set_experiment(experiment_name)
 
 # COMMAND ----------

--- a/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
+++ b/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
@@ -167,7 +167,7 @@ def log_to_model_description(run, success):
         description += """
             ---
         """.replace(" ", "")
-    description += "Model validation status: {0}\nValidation Details: {1}".format(status, run_link)
+    description += "Model Validation Status: {0}\nValidation Details: {1}".format(status, run_link)
     client.update_model_version(
         name=model_name,
         version=model_version,

--- a/{{cookiecutter.project_name}}/notebooks/Train.py
+++ b/{{cookiecutter.project_name}}/notebooks/Train.py
@@ -109,4 +109,6 @@ test_data.describe()
 model_version = r.get_artifact("registered_model_version")
 model_uri = f"models:/{model_version.name}/{model_version.version}"
 dbutils.jobs.taskValues.set("model_uri", model_uri)
+dbutils.jobs.taskValues.set("model_name", model_version.name)
+dbutils.jobs.taskValues.set("model_version", model_version.version)
 dbutils.notebook.exit(model_uri)

--- a/{{cookiecutter.project_name}}/notebooks/TrainWithFeatureStore.py
+++ b/{{cookiecutter.project_name}}/notebooks/TrainWithFeatureStore.py
@@ -231,4 +231,6 @@ model_registry_url = "https://{workspace_url}/#mlflow/models/{model_name}/versio
 # The returned model URI is needed by the model deployment notebook.
 model_uri = f"models:/{model_name}/{model_version}"
 dbutils.jobs.taskValues.set("model_uri", model_uri)
+dbutils.jobs.taskValues.set("model_name", model_name)
+dbutils.jobs.taskValues.set("model_version", model_version)
 dbutils.notebook.exit(model_uri)


### PR DESCRIPTION
Signed-off-by: Mingyu Li <mingyu.li@databricks.com>

Add model validation notebook and terraform file
Used the mlops-azure-cuj as example. PR in the example repo https://github.com/databricks/mlops-azure-cuj/pull/47

design doc https://docs.google.com/document/d/1zz5KEJpb8tgMfE__4NAn_jVmAokfbQjWJCQVNk6jQv4/edit#

***

## Failed model validation
https://user-images.githubusercontent.com/12734110/215229317-1890129b-8a8a-4852-90aa-5d7265a0cb3d.mov

***

## Successful model validation

https://user-images.githubusercontent.com/12734110/215229619-af43e15c-c4c1-4f7d-b297-e5d96b4e9f14.mov

## docs
<img width="1426" alt="Screen Shot 2023-01-30 at 1 59 52 PM" src="https://user-images.githubusercontent.com/12734110/215605093-b4fa50a0-9503-4de6-a05a-3b8858645385.png">

## How the notebook looks like in notebook view
<img width="2013" alt="Screen Shot 2023-01-27 at 4 38 22 PM" src="https://user-images.githubusercontent.com/12734110/215230581-606623e0-f8d7-4d5c-8b28-f23f39f2a007.png">
<img width="2007" alt="Screen Shot 2023-01-27 at 4 38 32 PM" src="https://user-images.githubusercontent.com/12734110/215230584-990705ec-568f-4cee-9f04-6abe8e1a6c6f.png">
<img width="1969" alt="Screen Shot 2023-01-27 at 4 38 46 PM" src="https://user-images.githubusercontent.com/12734110/215230586-4cf75648-2317-4064-b37f-dc254fd207d7.png">
<img width="2009" alt="Screen Shot 2023-01-27 at 4 39 10 PM" src="https://user-images.githubusercontent.com/12734110/215230589-da31723b-0aa7-42ab-9afc-dd2b98745f5f.png">
<img width="1995" alt="Screen Shot 2023-01-27 at 4 39 16 PM" src="https://user-images.githubusercontent.com/12734110/215230591-747deb52-1b86-44ad-9645-5fb4bfb5d5c8.png">
