### PR TITLE
[ML-27304][WIP] Remove unused env params in Feature Store ETL and Training notebooks

### DIFF
--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
@@ -95,7 +95,6 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "notebooks/Train",
                   "base_parameters": {
-                    "env": "staging",
                     "test_mode": "True"
                     }
                   },

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
@@ -95,6 +95,7 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "notebooks/Train",
                   "base_parameters": {
+                    "env": "staging"
                     "test_mode": "True"
                     }
                   },

--- a/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
+++ b/{{cookiecutter.project_name}}/.azure/devops-pipelines/tests-ci.yml
@@ -95,7 +95,7 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "notebooks/Train",
                   "base_parameters": {
-                    "env": "staging"
+                    "env": "staging",
                     "test_mode": "True"
                     }
                   },

--- a/{{cookiecutter.project_name}}/.github/workflows/run-tests-fs.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/run-tests-fs.yml
@@ -60,7 +60,6 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "notebooks/GenerateAndWriteFeatures", 
                   "base_parameters": {
-                    "env": "staging",
                     "test_mode": "True",
                     "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
                     "timestamp_column": "tpep_pickup_datetime",
@@ -88,7 +87,6 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "notebooks/GenerateAndWriteFeatures",
                   "base_parameters": {                    
-                    "env": "staging",
                     "test_mode": "True",
                     "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
                     "timestamp_column": "tpep_dropoff_datetime",
@@ -124,7 +122,6 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "notebooks/TrainWithFeatureStore",
                   "base_parameters": {
-                    "env": "staging",
                     "test_mode": "True",
                     "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
                     "experiment_name": "{{cookiecutter.mlflow_experiment_parent_dir}}/{{cookiecutter.experiment_base_name}}-test",

--- a/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
@@ -79,7 +79,6 @@ jobs:
           run-name: {{ cookiecutter.project_name}} Integration Test
           notebook-params-json: >
             {
-              "env": "staging",
               "test_mode": "True"
             }
           {% raw %}pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}{% endraw %}

--- a/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
@@ -77,7 +77,7 @@ jobs:
               }
             ]
           run-name: {{ cookiecutter.project_name}} Integration Test
-          {%- if cookiecutter.include_feature_store != "yes" %}
+          {%- if cookiecutter.include_feature_store == "no" %}
           notebook-params-json: >
             {
               "env": "staging",

--- a/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
@@ -77,8 +77,17 @@ jobs:
               }
             ]
           run-name: {{ cookiecutter.project_name}} Integration Test
+          {%- if cookiecutter.include_feature_store == "yes" %}
           notebook-params-json: >
             {
               "test_mode": "True"
             }
+          {%- else %}
+          notebook-params-json: >
+            {
+              "env": "staging",
+              "test_mode": "True"
+            }
+          {%- endif %}
+          
           {% raw %}pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}{% endraw %}

--- a/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
@@ -77,11 +77,7 @@ jobs:
               }
             ]
           run-name: {{ cookiecutter.project_name}} Integration Test
-          {%- if cookiecutter.include_feature_store == "yes" %}
-          notebook-params-json: >
-            {
-            }
-          {%- else %}
+          {%- if cookiecutter.include_feature_store != "yes" %}
           notebook-params-json: >
             {
               "env": "staging",

--- a/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/run-tests.yml
@@ -80,7 +80,6 @@ jobs:
           {%- if cookiecutter.include_feature_store == "yes" %}
           notebook-params-json: >
             {
-              "test_mode": "True"
             }
           {%- else %}
           notebook-params-json: >

--- a/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
@@ -24,6 +24,7 @@ resource "databricks_job" "model_training_job" {
     {%- else -%}notebook_task {
       notebook_path = "notebooks/Train"
       base_parameters = {
+        env = local.env
       }
     }{% endif %}
 

--- a/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
@@ -16,7 +16,6 @@ resource "databricks_job" "model_training_job" {
     {% if cookiecutter.include_feature_store == "yes" %}notebook_task {
       notebook_path = "notebooks/TrainWithFeatureStore"
       base_parameters = {
-        env                = local.env
         training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         experiment_name    = databricks_mlflow_experiment.experiment.name
         model_name         = "${local.env_prefix}{{cookiecutter.model_name}}"
@@ -25,7 +24,6 @@ resource "databricks_job" "model_training_job" {
     {%- else -%}notebook_task {
       notebook_path = "notebooks/Train"
       base_parameters = {
-        env = local.env
       }
     }{% endif %}
 

--- a/{{cookiecutter.project_name}}/databricks-config/prod/write-feature-table-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/write-feature-table-job.tf
@@ -16,7 +16,6 @@ resource "databricks_job" "write_feature_table_job" {
     notebook_task {
       notebook_path = "notebooks/GenerateAndWriteFeatures"
       base_parameters = {
-        env = local.env
         # TODO modify these arguments to reflect your setup.
         input_table_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         # TODO: Empty start/end dates will process the whole range. Update this as needed to process recent data.
@@ -43,7 +42,6 @@ resource "databricks_job" "write_feature_table_job" {
     notebook_task {
       notebook_path = "notebooks/GenerateAndWriteFeatures"
       base_parameters = {
-        env = local.env
         # TODO: modify these arguments to reflect your setup.
         input_table_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         # TODO: Empty start/end dates will process the whole range. Update this as needed to process recent data.

--- a/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
@@ -24,6 +24,7 @@ resource "databricks_job" "model_training_job" {
     {%- else -%}notebook_task {
       notebook_path = "notebooks/Train"
       base_parameters = {
+        env = local.env
       }
     }{% endif %}
 

--- a/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
@@ -23,7 +23,8 @@ resource "databricks_job" "model_training_job" {
     }
     {%- else -%}notebook_task {
       notebook_path = "notebooks/Train"
-      base_parameters = {}
+      base_parameters = {
+      }
     }{% endif %}
 
     new_cluster {
@@ -42,7 +43,9 @@ resource "databricks_job" "model_training_job" {
 
     notebook_task {
       notebook_path = "notebooks/TriggerModelDeploy"
-      base_parameters = {}
+      base_parameters = {
+        env = local.env
+      }
     }
 
     new_cluster {

--- a/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
@@ -16,7 +16,6 @@ resource "databricks_job" "model_training_job" {
     {% if cookiecutter.include_feature_store == "yes" %}notebook_task {
       notebook_path = "notebooks/TrainWithFeatureStore"
       base_parameters = {
-        env                = local.env
         training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         experiment_name    = databricks_mlflow_experiment.experiment.name
         model_name         = "${local.env_prefix}{{cookiecutter.model_name}}"
@@ -24,9 +23,7 @@ resource "databricks_job" "model_training_job" {
     }
     {%- else -%}notebook_task {
       notebook_path = "notebooks/Train"
-      base_parameters = {
-        env = local.env
-      }
+      base_parameters = {}
     }{% endif %}
 
     new_cluster {
@@ -45,9 +42,7 @@ resource "databricks_job" "model_training_job" {
 
     notebook_task {
       notebook_path = "notebooks/TriggerModelDeploy"
-      base_parameters = {
-        env = local.env
-      }
+      base_parameters = {}
     }
 
     new_cluster {

--- a/{{cookiecutter.project_name}}/databricks-config/staging/write-feature-table-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/write-feature-table-job.tf
@@ -16,7 +16,6 @@ resource "databricks_job" "write_feature_table_job" {
     notebook_task {
       notebook_path = "notebooks/GenerateAndWriteFeatures"
       base_parameters = {
-        env = local.env
         # TODO modify these arguments to reflect your setup.
         input_table_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         # TODO: Empty start/end dates will process the whole range. Update this as needed to process recent data.
@@ -42,7 +41,6 @@ resource "databricks_job" "write_feature_table_job" {
     notebook_task {
       notebook_path = "notebooks/GenerateAndWriteFeatures"
       base_parameters = {
-        env = local.env
         # TODO: modify these arguments to reflect your setup.
         input_table_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         # TODO: Empty start/end dates will process the whole range. Update this as needed to process recent data.

--- a/{{cookiecutter.project_name}}/notebooks/GenerateAndWriteFeatures.py
+++ b/{{cookiecutter.project_name}}/notebooks/GenerateAndWriteFeatures.py
@@ -7,7 +7,6 @@
 #
 # Parameters:
 #
-# * env (optional)  - String name of the current environment (dev, staging, or prod). Defaults to "dev".
 # * input_table_path (required)   - Path to input data.
 # * output_table_name (required)  - Fully qualified schema + Delta table name for the feature table where the features
 # *                                 will be written to. Note that this will create the Feature table if it does not
@@ -26,8 +25,6 @@
 # List of input args needed to run this notebook as a job.
 # Provide them via DB widgets or notebook arguments.
 #
-# Name of the current environment.
-dbutils.widgets.dropdown("env", "dev", ["dev", "staging", "prod"], "Environment Name")
 # A Hive-registered Delta table containing the input data.
 dbutils.widgets.text("input_table_path", "/databricks-datasets/nyctaxi-with-zipcodes/subsampled", label="Input Table Name")
 # Input start date. 
@@ -56,7 +53,6 @@ sys.path.append("../features")
 # COMMAND ----------
 # DBTITLE 1,Define input and output variables
 
-env = dbutils.widgets.get("env")
 input_table_path = dbutils.widgets.get("input_table_path")
 output_table_name = dbutils.widgets.get("output_table_name")
 input_start_date = dbutils.widgets.get("input_start_date")

--- a/{{cookiecutter.project_name}}/notebooks/TrainWithFeatureStore.py
+++ b/{{cookiecutter.project_name}}/notebooks/TrainWithFeatureStore.py
@@ -7,7 +7,6 @@
 #
 # Parameters:
 #
-# * env (optional)  - String name of the current environment (dev, staging, or prod). Defaults to "dev".
 # * training_data_path (required)   - Path to the training data.
 # * experiment_name (required)      - MLflow experiment name for the training runs. Will be created if it doesn't exist.
 # * model_name (required)           - MLflow registered model name to use for the trained model. Will be created if it
@@ -20,9 +19,6 @@
 
 # List of input args needed to run this notebook as a job.
 # Provide them via DB widgets or notebook arguments.
-#
-# Name of the current environment.
-dbutils.widgets.dropdown("env", "dev", ["dev", "staging", "prod"], "Environment Name")
 
 # Path to the Hive-registered Delta table containing the training data.
 dbutils.widgets.text("training_data_path", "/databricks-datasets/nyctaxi-with-zipcodes/subsampled", label="Path to the training data")
@@ -36,7 +32,6 @@ dbutils.widgets.text("model_name", "mlops-azure-cuj-model-test", label="Model Na
 # COMMAND ----------
 # DBTITLE 1,Define input and output variables
 
-env = dbutils.widgets.get("env")
 input_table_path = dbutils.widgets.get("training_data_path")
 experiment_name = dbutils.widgets.get("experiment_name")
 model_name = dbutils.widgets.get("model_name")


### PR DESCRIPTION
Removed unused env params in Feature Store ETL and Training notebooks

- {{cookiecutter.project_name}}/notebooks/GenerateAndWriteFeatures.py
- {{cookiecutter.project_name}}/notebooks/TrainWithFeatureStore.py
- And upstream TF files and CICD Yml files


The reason we remove the env param is because

- Staging and production models are already differentiated by their name in the TF config files: https://github.com/databricks/mlops-stack/blob/main/%7B%7Bcookiecutter.project_name%7D%7D/databricks-config/prod/training-job.tf#L22
- There is no need for differentiating feature tables by env and there is no use of env in downsteam APIs that we called.

Additional manual tests:
- Ran the notebooks on Databricks.
- Setup a dummy project on GitHub and created a dummy PR that triggers CI.

Testing with MLOps Azure CUJ Repo: https://github.com/databricks/mlops-azure-cuj/pull/55