### PR TITLE
[easy] Remove hard-coded MLOps Azure CUJ experiment name and model name

### DIFF
--- a/{{cookiecutter.project_name}}/notebooks/TrainWithFeatureStore.py
+++ b/{{cookiecutter.project_name}}/notebooks/TrainWithFeatureStore.py
@@ -24,10 +24,10 @@
 dbutils.widgets.text("training_data_path", "/databricks-datasets/nyctaxi-with-zipcodes/subsampled", label="Path to the training data")
 
 # MLflow experiment name.
-dbutils.widgets.text("experiment_name", "/mlops-azure-cuj/mlops-azure-cuj-experiment-test", label="MLflow experiment name")
+dbutils.widgets.text("experiment_name", "/{{cookiecutter.project_name}}/{{cookiecutter.experiment_base_name}}-test", label="MLflow experiment name")
 
 # MLflow registered model name to use for the trained mode..
-dbutils.widgets.text("model_name", "mlops-azure-cuj-model-test", label="Model Name")
+dbutils.widgets.text("model_name", "{{cookiecutter.model_name}}-test", label="Model Name")
 
 # COMMAND ----------
 # DBTITLE 1,Define input and output variables


### PR DESCRIPTION
Signed-off-by: Mingyu Li <mingyu.li@databricks.com>

## Before
Default experiment name `/mlops-azure-cuj/mlops-azure-cuj-experiment-test`
Default model name `mlops-azure-cuj-model-test`

---

## After
Create project with name "my-next-project". The correct experiment name and model name is reflected in the project.
<img width="1015" alt="Screen Shot 2023-02-09 at 1 59 52 PM" src="https://user-images.githubusercontent.com/12734110/217949033-e4cf6b3c-d0ed-4528-a067-7db8da67521d.png">
