### PR TITLE
Add model version column to batch inference output table

### DIFF
--- a/{{cookiecutter.project_name}}/notebooks/BatchInference.py
+++ b/{{cookiecutter.project_name}}/notebooks/BatchInference.py
@@ -47,7 +47,13 @@ assert input_table_name != "", "input_table_name notebook parameter must be spec
 assert output_table_name != "", "output_table_name notebook parameter must be specified"
 
 model_name = get_model_name(env)
-model_uri = f"models:/{model_name}/{get_deployed_model_stage_for_env(env)}"
+stage = get_deployed_model_stage_for_env(env)
+model_uri = f"models:/{model_name}/{stage}"
+
+# Get model version from stage
+from mlflow import MlflowClient
+model_version_infos = MlflowClient().search_model_versions("name = '%s'" % model_name)
+model_version = next(version for version in model_version_infos if version.current_stage == stage).version
 
 # COMMAND ----------
 

--- a/{{cookiecutter.project_name}}/notebooks/BatchInference.py
+++ b/{{cookiecutter.project_name}}/notebooks/BatchInference.py
@@ -60,5 +60,5 @@ model_version = next(version for version in model_version_infos if version.curre
 # DBTITLE 1,Load model and run inference
 from predict import predict_batch
 
-predict_batch(spark, model_uri, input_table_name, output_table_name)
+predict_batch(spark, model_uri, input_table_name, output_table_name, model_version)
 dbutils.notebook.exit(output_table_name)

--- a/{{cookiecutter.project_name}}/steps/predict.py
+++ b/{{cookiecutter.project_name}}/steps/predict.py
@@ -1,5 +1,5 @@
 import mlflow
-from pyspark.sql.functions import struct
+from pyspark.sql.functions import struct, lit
 
 
 def predict_batch(
@@ -15,7 +15,7 @@ def predict_batch(
     )
     output_df = table.withColumn(
         "prediction", predict(struct(*table.columns))
-    ).withColumn("model_version", model_version)
+    ).withColumn("model_version", lit(model_version))
     output_df.display()
     # Model predictions are written to the Delta table provided as input.
     # Delta is the default format in Databricks Runtime 8.0 and above.

--- a/{{cookiecutter.project_name}}/steps/predict.py
+++ b/{{cookiecutter.project_name}}/steps/predict.py
@@ -2,7 +2,9 @@ import mlflow
 from pyspark.sql.functions import struct
 
 
-def predict_batch(spark_session, model_uri, input_table_name, output_table_name):
+def predict_batch(
+    spark_session, model_uri, input_table_name, output_table_name, model_version
+):
     """
     Apply the model at the specified URI for batch inference on the table with name input_table_name,
     writing results to the table with name output_table_name
@@ -11,7 +13,9 @@ def predict_batch(spark_session, model_uri, input_table_name, output_table_name)
     predict = mlflow.pyfunc.spark_udf(
         spark_session, model_uri, result_type="string", env_manager="conda"
     )
-    output_df = table.withColumn("prediction", predict(struct(*table.columns)))
+    output_df = table.withColumn(
+        "prediction", predict(struct(*table.columns))
+    ).withColumn("model_version", model_version)
     output_df.display()
     # Model predictions are written to the Delta table provided as input.
     # Delta is the default format in Databricks Runtime 8.0 and above.


### PR DESCRIPTION
Signed-off-by: Mingyu Li <mingyu.li@databricks.com>

The model version column is required by databricks model monitoring

---
Test - Make the same change to mlops-azure-cuj branch model-validation-bugbash1 and run BatchInference
<img width="1712" alt="Screen Shot 2023-02-12 at 5 49 18 PM" src="https://user-images.githubusercontent.com/12734110/218353063-046214a5-ee81-4246-a04b-f8170968930a.png">






