### PR TITLE
Add experiment name to terraform workflow input

### DIFF
--- a/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
@@ -49,7 +49,7 @@ resource "databricks_job" "model_training_job" {
     notebook_task {
       notebook_path = "notebooks/ModelValidation"
       base_parameters = {
-        env = local.env
+        env             = local.env
         experiment_name = databricks_mlflow_experiment.experiment.name
         # Run mode for model validation. Possible values are :
         #   disabled : Do not run the model validation notebook.

--- a/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/prod/training-job.tf
@@ -50,6 +50,7 @@ resource "databricks_job" "model_training_job" {
       notebook_path = "notebooks/ModelValidation"
       base_parameters = {
         env = local.env
+        experiment_name = databricks_mlflow_experiment.experiment.name
         # Run mode for model validation. Possible values are :
         #   disabled : Do not run the model validation notebook.
         #   dry_run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.

--- a/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
@@ -46,6 +46,7 @@ resource "databricks_job" "model_training_job" {
       notebook_path = "notebooks/ModelValidation"
       base_parameters = {
         env = local.env
+        experiment_name = databricks_mlflow_experiment.experiment.name
         # Run mode for model validation. Possible values are :
         #   disabled : Do not run the model validation notebook.
         #   dry_run  : Run the model validation notebook. Ignore failed model validation rules and proceed to move model to Production stage.

--- a/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
+++ b/{{cookiecutter.project_name}}/databricks-config/staging/training-job.tf
@@ -45,7 +45,7 @@ resource "databricks_job" "model_training_job" {
     notebook_task {
       notebook_path = "notebooks/ModelValidation"
       base_parameters = {
-        env = local.env
+        env             = local.env
         experiment_name = databricks_mlflow_experiment.experiment.name
         # Run mode for model validation. Possible values are :
         #   disabled : Do not run the model validation notebook.

--- a/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
+++ b/{{cookiecutter.project_name}}/notebooks/ModelValidation.py
@@ -59,6 +59,7 @@ from mlflow.tracking.client import MlflowClient
 client = MlflowClient()
 
 env = dbutils.widgets.get("env")
+experiment_name = dbutils.widgets.get("experiment_name")
 _run_mode = dbutils.widgets.get("run_mode")
 if _run_mode.lower() == "disabled":
     dbutils.notebook.exit(0)
@@ -91,8 +92,6 @@ assert model_name != "", "model_name notebook parameter must be specified"
 assert model_version != "", "model_version notebook parameter must be specified"
 
 # set experiment
-with open("../databricks-config/output/prod.json", "r") as f:
-    experiment_name = json.load(f)["{{cookiecutter.project_name}}_experiment_name"]["value"]
 mlflow.set_experiment(experiment_name)
 
 # COMMAND ----------


### PR DESCRIPTION
Add experiment name to terraform workflow input so that both staging and prod workspace can get the correct experiment name.

## Test
Made the same changes to CUJ project, successfully run the training workflow with validation enabled.
<img width="1709" alt="Screen Shot 2023-02-17 at 10 41 28 PM" src="https://user-images.githubusercontent.com/12734110/219845717-ff6dd08e-11da-46ae-9a64-4e83ab5f74d7.png">
<img width="1714" alt="Screen Shot 2023-02-17 at 10 41 40 PM" src="https://user-images.githubusercontent.com/12734110/219845729-79637da3-6ad0-45e3-a2d1-275afe349530.png">
