### PR TITLE
Update validation run name to training run name plus suffix. Add training run link to validation run description

### DIFF
--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/validation/notebooks/ModelValidation.py
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/validation/notebooks/ModelValidation.py
@@ -172,15 +172,38 @@ evaluator_config = {}
 
 # COMMAND ----------
 
-eval_result = None
-err = None
+# helper methods
+def get_run_link(run_info):
+    return "[Run](#mlflow/experiments/{0}/runs/{1})".format(
+        run_info.experiment_id, run_info.run_id
+    )
+
+
+def get_training_run(model_name, model_version):
+    model_versions = client.search_model_versions(f"name='{model_name}'")
+    training_run_id_optional = [
+        version.run_id for version in model_versions if version.version == model_version
+    ]
+    if not training_run_id_optional:
+        print("Unable to find the training run!")
+        return None
+    return mlflow.get_run(run_id=training_run_id_optional[0])
+
+
+def generate_run_name(training_run):
+    return None if not training_run else training_run.info.run_name + "-validation"
+
+
+def generate_description(training_run):
+    return (
+        None
+        if not training_run
+        else "Model Training Details: {0}\n".format(get_run_link(training_run.info))
+    )
 
 
 def log_to_model_description(run, success):
-    run_info = run.info
-    run_link = "[Run](#mlflow/experiments/{0}/runs/{1})".format(
-        run_info.experiment_id, run_info.run_id
-    )
+    run_link = get_run_link(run.info)
     description = client.get_model_version(model_name, model_version).description
     status = "SUCCESS" if success else "FAILURE"
     if description != "":
@@ -193,9 +216,14 @@ def log_to_model_description(run, success):
     )
 
 
-# run evaluate
-with mlflow.start_run() as run, tempfile.TemporaryDirectory() as tmp_dir:
+# COMMAND ----------
 
+training_run = get_training_run(model_name, model_version)
+# run evaluate
+with mlflow.start_run(
+    run_name=generate_run_name(training_run),
+    description=generate_description(training_run),
+) as run, tempfile.TemporaryDirectory() as tmp_dir:
     validation_thresholds_file = os.path.join(tmp_dir, "validation_thresholds.txt")
     with open(validation_thresholds_file, "w") as f:
         if validation_thresholds:
@@ -206,7 +234,6 @@ with mlflow.start_run() as run, tempfile.TemporaryDirectory() as tmp_dir:
                     )
                 )
     mlflow.log_artifact(validation_thresholds_file)
-
     try:
         eval_result = mlflow.evaluate(
             model=model_uri,

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/validation/notebooks/ModelValidation.py
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/validation/notebooks/ModelValidation.py
@@ -180,14 +180,8 @@ def get_run_link(run_info):
 
 
 def get_training_run(model_name, model_version):
-    model_versions = client.search_model_versions(f"name='{model_name}'")
-    training_run_id_optional = [
-        version.run_id for version in model_versions if version.version == model_version
-    ]
-    if not training_run_id_optional:
-        print("Unable to find the training run!")
-        return None
-    return mlflow.get_run(run_id=training_run_id_optional[0])
+    version = client.get_model_version(model_name, model_version)
+    return mlflow.get_run(run_id=version.run_id)
 
 
 def generate_run_name(training_run):


### PR DESCRIPTION
This is the effort to better associate the validation run with the training run since they are in the same experiment.

## Design Doc
One decision doc https://docs.google.com/document/d/1KK7G3qz3tNc7ZPmCaZPRJ1fDVH5SyhFMtCJ8aWk4utM/edit#

## Test in example project

### Run the training workflow

<img width="1473" alt="Screen Shot 2023-02-23 at 11 08 42 PM" src="https://user-images.githubusercontent.com/12734110/221117059-c1c3a7df-edc8-4227-a5e1-59836b4f23b8.png">

### Validation run name = training run name + "-validation" 

<img width="1585" alt="Screen Shot 2023-02-23 at 11 08 55 PM" src="https://user-images.githubusercontent.com/12734110/221117087-b8421694-724e-4da5-be24-793447a5fb6e.png">

### The validation run correctly link to the training run

<img width="1660" alt="Screen Shot 2023-02-23 at 11 23 57 PM" src="https://user-images.githubusercontent.com/12734110/221117536-4a29d290-175f-4ad6-b7e9-9c83fde3ccc1.png">

### The corresponding example project commit 
https://github.com/databricks/mlops-azure-cuj/commit/7ee0c3f86ff5b6c389fa4e322a2d98fb899e6c47
