### PR TITLE
Fix github CD action

### DIFF
--- a/local_extensions.py
+++ b/local_extensions.py
@@ -19,8 +19,8 @@ def generate_doc_link(path, cloud):
 
     :return: documentation links for the specified cloud
     """
-    if cloud == "azure" and path == "repos/set-up-git-integration.html":
-        path = "repos/repos-setup"
+    if cloud == "aws" and path == "repos/git-operations-with-repos#add-a-repo-and-connect-remotely-later":
+        path = "repos/git-operations-with-repos.html#add-a-repo-connected-to-a-remote-repo"
     baseUrl = AZURE_DOC_BASE if cloud == "azure" else AWS_DOC_BASE
     newDocsPath = path.replace(".html", "") if cloud == "azure" else path
     return f"{baseUrl}/{newDocsPath}"

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/terraform-cd.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/terraform-cd.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}{% endraw %}
+        {% raw %}run: ../../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - uses: hashicorp/setup-terraform@v1
       - name: Terraform fmt
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v3
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.prodAzureSpTenantId }} ${{ secrets.prodAzureSpApplicationId }} ${{ secrets.prodAzureSpClientSecret }}{% endraw %}
+        {% raw %}run: ../../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.prodAzureSpTenantId }} ${{ secrets.prodAzureSpApplicationId }} ${{ secrets.prodAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - uses: hashicorp/setup-terraform@v1
       - name: Terraform fmt

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/terraform-ci.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/terraform-ci.yml
@@ -28,7 +28,7 @@ jobs:
           ref: {% raw %}${{ github.event.pull_request.head.sha || github.sha }}{% endraw %}
         {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}{% endraw %}
+        {% raw %}run: ../../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.stagingAzureSpTenantId }} ${{ secrets.stagingAzureSpApplicationId }} ${{ secrets.stagingAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - uses: hashicorp/setup-terraform@v1
       - name: Terraform fmt
@@ -112,7 +112,7 @@ jobs:
           ref: {% raw %}${{ github.event.pull_request.head.sha || github.sha }}{% endraw %}
       {%- if cookiecutter.cloud == "azure" %}
       - name: Generate AAD Token
-        {% raw %}run: ../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.prodAzureSpTenantId }} ${{ secrets.prodAzureSpApplicationId }} ${{ secrets.prodAzureSpClientSecret }}{% endraw %}
+        {% raw %}run: ../../.github/workflows/scripts/generate-aad-token.sh ${{ secrets.prodAzureSpTenantId }} ${{ secrets.prodAzureSpApplicationId }} ${{ secrets.prodAzureSpClientSecret }}{% endraw %}
         {%- endif %}
       - uses: hashicorp/setup-terraform@v1
       - name: Terraform fmt

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-developer-guide-fs.md
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-developer-guide-fs.md
@@ -50,14 +50,14 @@ You'll need:
 * To set up [Databricks Repos]({{ "repos/index.html" | generate_doc_link(cookiecutter.cloud) }}): see instructions below
 
 #### Configuring Databricks Repos
-To use Repos, [set up git integration]({{ "repos/set-up-git-integration.html" | generate_doc_link(cookiecutter.cloud) }}) in your dev workspace.
+To use Repos, [set up git integration]({{ "repos/repos-setup.html" | generate_doc_link(cookiecutter.cloud) }}) in your dev workspace.
 
 If the current project has already been pushed to a hosted Git repo, follow the
-[UI workflow]({{ "repos/work-with-notebooks-other-files.html#clone-a-remote-git-repository" | generate_doc_link(cookiecutter.cloud) }})
+[UI workflow]({{ "repos/git-operations-with-repos#add-a-repo-and-connect-remotely-later" | generate_doc_link(cookiecutter.cloud) }})
 to clone it into your dev workspace and iterate. 
 
 Otherwise, e.g. if iterating on ML code for a new project, follow the steps below:
-* Follow the [UI workflow]({{ "repos/work-with-notebooks-other-files.html#clone-a-remote-git-repository" | generate_doc_link(cookiecutter.cloud) }})
+* Follow the [UI workflow]({{ "repos/git-operations-with-repos#add-a-repo-and-connect-remotely-later" | generate_doc_link(cookiecutter.cloud) }})
   for creating a repo, but uncheck the "Create repo by cloning a Git repository" checkbox.
 * Install the `dbx` CLI via `pip install --upgrade dbx`
 * Run `databricks configure --profile {{cookiecutter.project_name}}-dev --token --host <your-dev-workspace-url>`, passing the URL of your dev workspace.

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-developer-guide.md
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-developer-guide.md
@@ -50,14 +50,14 @@ You'll need:
 * To set up [Databricks Repos]({{ "repos/index.html" | generate_doc_link(cookiecutter.cloud) }}): see instructions below
 
 #### Configuring Databricks Repos
-To use Repos, [set up git integration]({{ "repos/set-up-git-integration.html" | generate_doc_link(cookiecutter.cloud) }}) in your dev workspace.
+To use Repos, [set up git integration]({{ "repos/repos-setup.html" | generate_doc_link(cookiecutter.cloud) }}) in your dev workspace.
 
 If the current project has already been pushed to a hosted Git repo, follow the
-[UI workflow]({{ "repos/work-with-notebooks-other-files.html#clone-a-remote-git-repository" | generate_doc_link(cookiecutter.cloud) }})
+[UI workflow]({{ "repos/git-operations-with-repos#add-a-repo-and-connect-remotely-later" | generate_doc_link(cookiecutter.cloud) }})
 to clone it into your dev workspace and iterate.
 
 Otherwise, e.g. if iterating on ML code for a new project, follow the steps below:
-* Follow the [UI workflow]({{ "repos/work-with-notebooks-other-files.html#clone-a-remote-git-repository" | generate_doc_link(cookiecutter.cloud) }})
+* Follow the [UI workflow]({{ "repos/git-operations-with-repos#add-a-repo-and-connect-remotely-later" | generate_doc_link(cookiecutter.cloud) }})
   for creating a repo, but uncheck the "Create repo by cloning a Git repository" checkbox.
 * Install the `dbx` CLI via `pip install --upgrade dbx`
 * Run `databricks configure --profile {{cookiecutter.project_name}}-dev --token --host <your-dev-workspace-url>`, passing the URL of your dev workspace.


### PR DESCRIPTION
After refactoring mlops project layout, the github action for CD didn't have correct reference to generate-aad-token.sh  script. The PR is to fix it.

### Test in CUJ project. 
Terraform CD action
<img width="1696" alt="Screen Shot 2023-02-28 at 1 24 21 PM" src="https://user-images.githubusercontent.com/12734110/221983971-d613a90e-ae42-445c-8e24-26af7a371ae5.png">

Run the training job
<img width="1695" alt="Screen Shot 2023-02-28 at 1 24 34 PM" src="https://user-images.githubusercontent.com/12734110/221984087-89981e60-7637-4170-95d9-3d5702e848f7.png">
<img width="1679" alt="Screen Shot 2023-02-28 at 1 27 28 PM" src="https://user-images.githubusercontent.com/12734110/221984093-9040f761-b73c-4ead-af20-40b657a4a35e.png">
