### PR TITLE
Fix feature store notebook flow

### DIFF
--- a/.github/workflows/run-checks.yaml
+++ b/.github/workflows/run-checks.yaml
@@ -24,4 +24,5 @@ jobs:
             pip install -r dev-requirements.txt
       - name: Run tests with pytest
         run: |
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           pytest tests --large -vv --black

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The default stack in this repo includes three modular components:
 | Component                  | Description                                                                                                                                                           | Why it's useful                                                                                                                                                                         |
 |----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | ML Code                    | Example ML project structure, with unit tested Python modules and notebooks using [MLflow recipes](https://mlflow.org/docs/latest/recipes.html)                     | Quickly iterate on ML problems, without worrying about refactoring your code into tested modules for productionization later on.                                                        |
-| ML Resource Config as Code | ML pipeline resources (training and batch inference jobs, etc) defined through [Terraform](https://docs.microsoft.com/en-us/azure/databricks/dev-tools/terraform/)    | Govern, audit, and deploy changes to your ML resources (e.g. "use a larger instance type for automated model retraining") through pull requests, rather than adhoc changes made via UI. |
+| ML Resource Config as Code | ML pipeline resources (training and batch inference jobs, etc) defined through [Terraform](https://learn.microsoft.com/en-us/azure/databricks/dev-tools/terraform/)    | Govern, audit, and deploy changes to your ML resources (e.g. "use a larger instance type for automated model retraining") through pull requests, rather than adhoc changes made via UI. |
 | CI/CD                      | [GitHub Actions](https://github.com/actions) or [Azure DevOps](https://azure.microsoft.com/en-gb/products/devops/) workflows to test and deploy ML code and resources | Ship ML code faster and with confidence: ensure all production changes are performed through automation and that only tested code is deployed to prod                                   |
 
 
@@ -59,7 +59,7 @@ ready to productionize a model. We recommend specifying any known parameters upf
  * ``mlflow_experiment_parent_dir``: Base Databricks workspace directory under which an MLflow experiment for the
    current project will be created. The service principals used for CI/CD must have "Can Manage" permissions
    ([AWS](https://docs.databricks.com/security/access-control/workspace-acl.html#folder-permissions) |
-   [Azure](https://docs.microsoft.com/en-us/azure/databricks/security/access-control/workspace-acl#--folder-permissions) |
+   [Azure](https://learn.microsoft.com/en-us/azure/databricks/security/access-control/workspace-acl#--folder-permissions) |
    [GCP](https://docs.gcp.databricks.com/security/access-control/workspace-acl.html#folder-permissions)) on this directory.
    We recommend using a dedicated directory for the current project, e.g. `/MLOps/<project_name>`, to isolate resources
    created for different projects.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -24,6 +24,7 @@ mlp_paths = [
     os.path.join(project_name, "tests", "training", "test_sample.parquet"),
     os.path.join(project_name, "tests", "training", "transform_test.py"),
     os.path.join("docs", "ml-developer-guide.md"),
+    os.path.join(".github", "workflows", "run-tests.yml"),
 ]
 
 feature_store_paths = [

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -112,7 +112,7 @@ def test_no_databricks_doc_strings_before_project_generation():
     assert_no_disallowed_strings_in_files(
         file_paths=test_paths,
         disallowed_strings=[
-            "https://docs.microsoft.com/en-us/azure/databricks",
+            "https://learn.microsoft.com/en-us/azure/databricks",
             "https://docs.databricks.com/",
             "https://docs.gcp.databricks.com/",
         ],

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -220,8 +220,8 @@ def test_generate_succeeds_with_valid_params(tmpdir, valid_params):
 @pytest.mark.parametrize(
     "experiment_parent_dir,expected_dir",
     [
-        ("/mlops-project-directory/", "/mlops-project-directory-prod"),
-        ("/Users/test@databricks.com/project/", "/Users/test@databricks.com/project-prod"),
+        ("/mlops-project-directory/", "/mlops-project-directory-${local.env}"),
+        ("/Users/test@databricks.com/project/", "/Users/test@databricks.com/project-${local.env}"),
     ],
 )
 def test_strip_slash_if_needed_from_mlflow_experiment_parent_dir(
@@ -342,7 +342,7 @@ def test_generate_project_default_project_name_params(tmpdir):
         / "terraform/prod/locals.tf"
     ).read_text("utf-8")
     assert (
-        f'mlflow_experiment_parent_dir = "/{DEFAULT_PROJECT_NAME}-prod"'
+        f'mlflow_experiment_parent_dir = "/{DEFAULT_PROJECT_NAME}-${{local.env}}"'
         in tf_config_contents
     )
 

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -223,7 +223,7 @@ def test_generate_succeeds_with_valid_params(tmpdir, valid_params):
         ("/mlops-project-directory/", "/mlops-project-directory-${local.env}"),
         (
             "/Users/test@databricks.com/project/",
-            "/Users/test@databricks.com/project-${local.env}"
+            "/Users/test@databricks.com/project-${local.env}",
         ),
     ],
 )

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -221,7 +221,10 @@ def test_generate_succeeds_with_valid_params(tmpdir, valid_params):
     "experiment_parent_dir,expected_dir",
     [
         ("/mlops-project-directory/", "/mlops-project-directory-${local.env}"),
-        ("/Users/test@databricks.com/project/", "/Users/test@databricks.com/project-${local.env}"),
+        (
+                "/Users/test@databricks.com/project/",
+                "/Users/test@databricks.com/project-${local.env}"
+        ),
     ],
 )
 def test_strip_slash_if_needed_from_mlflow_experiment_parent_dir(

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -222,8 +222,8 @@ def test_generate_succeeds_with_valid_params(tmpdir, valid_params):
     [
         ("/mlops-project-directory/", "/mlops-project-directory-${local.env}"),
         (
-                "/Users/test@databricks.com/project/",
-                "/Users/test@databricks.com/project-${local.env}"
+            "/Users/test@databricks.com/project/",
+            "/Users/test@databricks.com/project-${local.env}"
         ),
     ],
 )

--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -220,8 +220,8 @@ def test_generate_succeeds_with_valid_params(tmpdir, valid_params):
 @pytest.mark.parametrize(
     "experiment_parent_dir,expected_dir",
     [
-        ("/mlops-project-directory/", "/mlops-project-directory"),
-        ("/Users/test@databricks.com/project/", "/Users/test@databricks.com/project"),
+        ("/mlops-project-directory/", "/mlops-project-directory-prod"),
+        ("/Users/test@databricks.com/project/", "/Users/test@databricks.com/project-prod"),
     ],
 )
 def test_strip_slash_if_needed_from_mlflow_experiment_parent_dir(
@@ -342,7 +342,7 @@ def test_generate_project_default_project_name_params(tmpdir):
         / "terraform/prod/locals.tf"
     ).read_text("utf-8")
     assert (
-        f'mlflow_experiment_parent_dir = "/{DEFAULT_PROJECT_NAME}"'
+        f'mlflow_experiment_parent_dir = "/{DEFAULT_PROJECT_NAME}-prod"'
         in tf_config_contents
     )
 

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -32,7 +32,7 @@ def test_generated_yaml_format(cicd_platform, generated_project_dir):
 @pytest.mark.parametrize(
     "cicd_platform", ["GitHub Actions", "GitHub Actions for GitHub Enterprise Servers"]
 )
-@pytest.mark.parametrize("include_feature_store", ["yes", "no"])
+@pytest.mark.parametrize("include_feature_store", ["no"])
 @parametrize_by_cloud
 def test_run_unit_tests_workflow(cicd_platform, generated_project_dir):
     """Test that the GitHub workflow for running unit tests in the materialized project passes"""
@@ -42,6 +42,27 @@ def test_run_unit_tests_workflow(cicd_platform, generated_project_dir):
         """
         git init
         act workflow_dispatch --workflows .github/workflows/run-tests.yml -j "unit_tests"
+        """,
+        shell=True,
+        check=True,
+        executable="/bin/bash",
+        cwd=(generated_project_dir / "my-mlops-project"),
+    )
+
+@pytest.mark.large
+@pytest.mark.parametrize(
+    "cicd_platform", ["GitHub Actions", "GitHub Actions for GitHub Enterprise Servers"]
+)
+@pytest.mark.parametrize("include_feature_store", ["yes"])
+@parametrize_by_cloud
+def test_run_unit_tests_feature_store_workflow(cicd_platform, generated_project_dir):
+    """Test that the GitHub workflow for running unit tests passes for feature store"""
+    # We only test the unit test workflow, as it's the only one that doesn't require
+    # Databricks REST API or Terraform remote state credentials
+    subprocess.run(
+        """
+        git init
+        act workflow_dispatch --workflows .github/workflows/run-tests-fs.yml -j "unit_tests"
         """,
         shell=True,
         check=True,

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -49,6 +49,7 @@ def test_run_unit_tests_workflow(cicd_platform, generated_project_dir):
         cwd=(generated_project_dir / "my-mlops-project"),
     )
 
+
 @pytest.mark.large
 @pytest.mark.parametrize(
     "cicd_platform", ["GitHub Actions", "GitHub Actions for GitHub Enterprise Servers"]

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -41,7 +41,7 @@ def test_run_unit_tests_workflow(cicd_platform, generated_project_dir):
     subprocess.run(
         """
         git init
-        act workflow_dispatch --workflows .github/workflows/run-tests.yml -j "unit_tests"
+        act -s GITHUB_TOKEN workflow_dispatch --workflows .github/workflows/run-tests.yml -j "unit_tests"
         """,
         shell=True,
         check=True,
@@ -62,7 +62,7 @@ def test_run_unit_tests_feature_store_workflow(cicd_platform, generated_project_
     subprocess.run(
         """
         git init
-        act workflow_dispatch --workflows .github/workflows/run-tests-fs.yml -j "unit_tests"
+        act -s GITHUB_TOKEN workflow_dispatch --workflows .github/workflows/run-tests-fs.yml -j "unit_tests"
         """,
         shell=True,
         check=True,

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
@@ -24,9 +24,9 @@ jobs:
           python-version: 3.8
       # Feature store tests bring up a local Spark session, so Java is required.
       - uses: actions/setup-java@v2
-      with:
-        distribution: 'temurin'
-        java-version: '11'
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
@@ -122,9 +122,9 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "{{cookiecutter.project_name}}/feature_engineering/notebooks/TrainWithFeatureStore",
                   "base_parameters": {
-                    "test_mode": "True",
+                    "env": "staging"
                     "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
-                    "experiment_name": "{{cookiecutter.mlflow_experiment_parent_dir}}/{{cookiecutter.experiment_base_name}}-test",
+                    "experiment_name": "{{cookiecutter.mlflow_experiment_parent_dir}}-staging/{{cookiecutter.experiment_base_name}}-test",
                     "model_name": "{{cookiecutter.model_name}}-test"
                   }
                 },

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
@@ -60,7 +60,6 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "{{cookiecutter.project_name}}/feature_engineering/notebooks/GenerateAndWriteFeatures", 
                   "base_parameters": {
-                    "test_mode": "True",
                     "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
                     "timestamp_column": "tpep_pickup_datetime",
                     "output_table_name": "feature_store_taxi_example.trip_pickup_features_test",
@@ -87,7 +86,6 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "{{cookiecutter.project_name}}/feature_engineering/notebooks/GenerateAndWriteFeatures",
                   "base_parameters": {                    
-                    "test_mode": "True",
                     "input_table_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
                     "timestamp_column": "tpep_dropoff_datetime",
                     "output_table_name": "feature_store_taxi_example.trip_dropoff_features_test",
@@ -122,10 +120,12 @@ jobs:
                 "notebook_task": {
                   "notebook_path": "{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore",
                   "base_parameters": {
-                    "env": "staging"
+                    "env": "staging",
                     "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
                     "experiment_name": "{{cookiecutter.mlflow_experiment_parent_dir}}-staging/{{cookiecutter.experiment_base_name}}-test",
-                    "model_name": "{{cookiecutter.model_name}}-test"
+                    "model_name": "{{cookiecutter.model_name}}-test",
+                    "pickup_features_table": "feature_store_taxi_example.trip_pickup_features_test"
+                    "dropoff_features_table": "feature_store_taxi_example.trip_dropoff_features_test"
                   }
                 },
                 "new_cluster": {

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
@@ -120,7 +120,7 @@ jobs:
                   }
                 ],
                 "notebook_task": {
-                  "notebook_path": "{{cookiecutter.project_name}}/feature_engineering/notebooks/TrainWithFeatureStore",
+                  "notebook_path": "{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore",
                   "base_parameters": {
                     "env": "staging"
                     "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
@@ -22,6 +22,11 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      # Feature store tests bring up a local Spark session, so Java is required.
+      - uses: actions/setup-java@v2
+      with:
+        distribution: 'temurin'
+        java-version: '11'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests-fs.yml
@@ -124,7 +124,7 @@ jobs:
                     "training_data_path": "/databricks-datasets/nyctaxi-with-zipcodes/subsampled",
                     "experiment_name": "{{cookiecutter.mlflow_experiment_parent_dir}}-staging/{{cookiecutter.experiment_base_name}}-test",
                     "model_name": "{{cookiecutter.model_name}}-test",
-                    "pickup_features_table": "feature_store_taxi_example.trip_pickup_features_test"
+                    "pickup_features_table": "feature_store_taxi_example.trip_pickup_features_test",
                     "dropoff_features_table": "feature_store_taxi_example.trip_dropoff_features_test"
                   }
                 },

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/run-tests.yml
@@ -20,13 +20,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
-       {%- if cookiecutter.include_feature_store == "yes" %}
-      # Feature store tests bring up a local Spark session, so Java is required.
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-          {%- endif %}
       - name: Install dependencies
         run: |
             python -m pip install --upgrade pip
@@ -49,11 +42,7 @@ jobs:
         uses: databricks/run-notebook@v0
         id: train
         with:
-          {%- if cookiecutter.include_feature_store == "yes" %}
-          local-notebook-path: {{ cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore.py
-          {%- else %}
           local-notebook-path: {{ cookiecutter.project_name}}/training/notebooks/Train.py
-          {%- endif %}
           {% raw %}git-commit: ${{ github.event.pull_request.head.sha || github.sha }}{% endraw %}
           git-provider: {{ cookiecutter.cicd_platform }}
           new-cluster-json: >
@@ -78,12 +67,10 @@ jobs:
               }
             ]
           run-name: {{ cookiecutter.project_name}} Integration Test
-          {%- if cookiecutter.include_feature_store == "no" %}
           notebook-params-json: >
             {
               "env": "staging",
               "test_mode": "True"
             }
-          {%- endif %}
-          
+
           {% raw %}pr-comment-github-token: ${{ secrets.GITHUB_TOKEN }}{% endraw %}

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.mlops-setup-scripts/README.md
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.mlops-setup-scripts/README.md
@@ -69,8 +69,8 @@ To use the scripts, you must:
 * Be able to create Git tokens with permission to check out the current repository
 {% if cookiecutter.cloud == "azure" -%}
 * Determine the Azure AAD tenant (directory) ID and subscription associated with your staging and prod workspaces,
-  and verify that you have at least [Application.ReadWrite.All](https://docs.microsoft.com/en-us/graph/permissions-reference#application-resource-permissions) permissions on
-  the AAD tenant and ["Contributor" permissions](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#all) on
+  and verify that you have at least [Application.ReadWrite.All](https://learn.microsoft.com/en-us/graph/permissions-reference#application-resource-permissions) permissions on
+  the AAD tenant and ["Contributor" permissions](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#all) on
   the subscription. To do this:
     1. Navigate to the [Azure Databricks resource page](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Databricks%2Fworkspaces) in the Azure portal. Ensure there are no filters configured in the UI, i.e. that
        you're viewing workspaces across all Subscriptions and Resource Groups.
@@ -80,15 +80,15 @@ To use the scripts, you must:
        the workspace name
     3. If you can't find the workspaces, switch to another directory by clicking your profile info in the top-right of the Azure Portal, then
        repeat steps i) and ii). If you still can't find the workspace, ask your Azure account admin to ensure that you have
-       at least ["Contributor" permissions](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#all)
+       at least ["Contributor" permissions](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#all)
        on the subscription containing the workspaces. After confirming that the staging and prod workspaces are in the current directory, proceed to the next steps.
     4. The [Azure Databricks resource page](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Databricks%2Fworkspaces)
        contains links to the subscription containing your staging and prod workspaces. Click into the subscription, copy its ID ("Subscription ID"), and
        store it as an environment variable by running `export AZURE_SUBSCRIPTION_ID=<subscription-id>`
     5. Verify that you have "Contributor" access by clicking into
        "Access Control (IAM)" > "View my access" within the subscription UI,
-       as described in [this doc page](https://docs.microsoft.com/en-us/azure/role-based-access-control/check-access#step-1-open-the-azure-resources).
-       If you don't have [Contributor permissions](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#all),
+       as described in [this doc page](https://learn.microsoft.com/en-us/azure/role-based-access-control/check-access#step-1-open-the-azure-resources).
+       If you don't have [Contributor permissions](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#all),
        ask an Azure account admin to grant access.
     6. Find the current tenant ID
        by navigating to [this page](https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Properties),
@@ -97,7 +97,7 @@ To use the scripts, you must:
     7. Verify that you can create and manage service principals in the AAD tenant, by opening the
        [App registrations UI](https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/RegisteredApps)
        under the Azure Active Directory resource within the Azure portal. Then, verify that you can click "New registration" to create
-       a new AAD application, but don't actually create one. If unable to click "New registration", ask your Azure admin to grant you [Application.ReadWrite.All](https://docs.microsoft.com/en-us/graph/permissions-reference#application-resource-permissions) permissions
+       a new AAD application, but don't actually create one. If unable to click "New registration", ask your Azure admin to grant you [Application.ReadWrite.All](https://learn.microsoft.com/en-us/graph/permissions-reference#application-resource-permissions) permissions
   {% elif cookiecutter.cloud == "aws" -%}
 * Have permission to manage AWS IAM users and attached IAM policies (`"iam:*"` permissions) in the current AWS account.
   If you lack sufficient permissions, you'll see an error message describing any missing permissions when you

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.mlops-setup-scripts/cicd/provider.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.mlops-setup-scripts/cicd/provider.tf
@@ -25,7 +25,7 @@ terraform {
   // The `backend` block below configures the azurerm backend
   // (docs:
   // https://www.terraform.io/language/settings/backends/azurerm and
-  // https://docs.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage)
+  // https://learn.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage)
   // for storing Terraform state in Azure Blob Storage. The targeted Azure Blob Storage bucket is
   // provisioned by the Terraform config under .mlops-setup-scripts/terraform:
   //

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.mlops-setup-scripts/cicd/variables.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.mlops-setup-scripts/cicd/variables.tf
@@ -3,7 +3,7 @@ variable "git_token" {
   {% if cookiecutter.cicd_platform in ["gitHub", "gitHubEnterprise"] -%}
   description = "Git token used to (1) checkout ML code to run during CI and (2) call back from Databricks -> GitHub Actions to trigger a model deployment CD workflow when automated model retraining completes. Must have read and write permissions on the Git repo containing the current ML project"
   {% elif cookiecutter.cicd_platform == "azureDevOpsServices" -%}
-  description = "Azure DevOps personal access token (PAT) used by the created service principal to create Azure DevOps Pipelines and checkout ML code to run during CI/CD. PAT must have read, write and manage permissions for Build and Code scopes on the Azure DevOps project. See the following on how to create and use PATs (https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows)"
+  description = "Azure DevOps personal access token (PAT) used by the created service principal to create Azure DevOps Pipelines and checkout ML code to run during CI/CD. PAT must have read, write and manage permissions for Build and Code scopes on the Azure DevOps project. See the following on how to create and use PATs (https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows)"
   {% endif -%}
   sensitive   = true
   validation {

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.mlops-setup-scripts/terraform/main-azure.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.mlops-setup-scripts/terraform/main-azure.tf
@@ -1,4 +1,4 @@
-// Copied from https://docs.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage?tabs=terraform#code-try-3
+// Copied from https://learn.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage?tabs=terraform#code-try-3
 terraform {
   required_providers {
     azurerm = {

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-pull-request.md
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-pull-request.md
@@ -34,7 +34,7 @@ is planned for the future.
 ## Viewing test status and debug logs
 Opening a pull request will trigger a 
 {%- if cookiecutter.cicd_platform == "gitHub" -%} 
-[workflow](../.github/workflows/run-tests.yml) 
+[workflow](../.github/workflows/run-tests{% if cookiecutter.include_feature_store %}-fs{% endif %}.yml) 
 {%- elif cookiecutter.cicd_platform == "azureDevopsServices" -%} 
 [Azure DevOps Pipeline](../.azure/devops-pipelines/tests-ci.yml)
 {% endif %} 

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-pull-request.md
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-pull-request.md
@@ -34,7 +34,7 @@ is planned for the future.
 ## Viewing test status and debug logs
 Opening a pull request will trigger a 
 {%- if cookiecutter.cicd_platform == "gitHub" -%} 
-[workflow](../.github/workflows/run-tests{% if cookiecutter.include_feature_store %}-fs{% endif %}.yml) 
+[workflow](../.github/workflows/run-tests{% if cookiecutter.include_feature_store == "yes" %}-fs{% endif %}.yml) 
 {%- elif cookiecutter.cicd_platform == "azureDevopsServices" -%} 
 [Azure DevOps Pipeline](../.azure/devops-pipelines/tests-ci.yml)
 {% endif %} 

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/prod/locals.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/prod/locals.tf
@@ -1,14 +1,14 @@
 locals {
-  // Base workspace directory under which to create resources in the workspace for the current MLOps project
-  // We assume the service principal used to deploy resources has CAN MANAGE permissions on directory
-  // You may need to modify this value if you'd like to use a different directory for per-project resources
-  mlflow_experiment_parent_dir = "{{cookiecutter.mlflow_experiment_parent_dir}}"
   // Current environment
   env = "prod"
   // Env-specific prefix to prepend to resource names. We recommend creating staging/prod resources
   // in separate workspaces to isolate prod resources from code running in CI, but this prefix
   // unblocks using a shared workspace across envs.
   env_prefix = "${local.env}-"
+  // Base workspace directory under which to create resources in the workspace for the current MLOps project
+  // We assume the service principal used to deploy resources has CAN MANAGE permissions on directory
+  // You may need to modify this value if you'd like to use a different directory for per-project resources
+  mlflow_experiment_parent_dir = "{{cookiecutter.mlflow_experiment_parent_dir}}-${local.env}"
   // User group to give read permissions for the batch inference and model training jobs
   read_user_group = "{{cookiecutter.read_user_group}}"
 }

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/prod/provider.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/prod/provider.tf
@@ -3,7 +3,7 @@ terraform {
   // The `backend` block below configures the azurerm backend
   // (docs:
   // https://www.terraform.io/language/settings/backends/azurerm and
-  // https://docs.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage)
+  // https://learn.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage)
   // for storing Terraform state in Azure Blob Storage.
   // We recommend running the setup scripts in mlops-setup-scripts/terraform to provision the Azure Blob Storage
   // container referenced below and store appropriate credentials for accessing the container from CI/CD.

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/prod/training-job.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/prod/training-job.tf
@@ -16,7 +16,7 @@ resource "databricks_job" "model_training_job" {
     {% if cookiecutter.include_feature_store == "yes" %}notebook_task {
       notebook_path = "{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore"
       base_parameters = {
-        env                = "${local.env}"
+        env                = local.env
         training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         experiment_name    = databricks_mlflow_experiment.experiment.name
         model_name         = "${local.env_prefix}{{cookiecutter.model_name}}"

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/prod/training-job.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/prod/training-job.tf
@@ -16,6 +16,7 @@ resource "databricks_job" "model_training_job" {
     {% if cookiecutter.include_feature_store == "yes" %}notebook_task {
       notebook_path = "{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore"
       base_parameters = {
+        env                = "${local.env}"
         training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         experiment_name    = databricks_mlflow_experiment.experiment.name
         model_name         = "${local.env_prefix}{{cookiecutter.model_name}}"

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/staging/locals.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/staging/locals.tf
@@ -1,14 +1,14 @@
 locals {
-  // Base workspace directory under which to create resources in the workspace for the current MLOps project
-  // We assume the service principal used to deploy resources has CAN MANAGE permissions on directory
-  // You may need to modify this value if you'd like to use a different directory for per-project resources
-  mlflow_experiment_parent_dir = "{{cookiecutter.mlflow_experiment_parent_dir}}"
   // Current environment
   env = "staging"
   // Env-specific prefix to prepend to resource names. We recommend creating staging/prod resources
   // in separate workspaces to isolate prod resources from code running in CI, but this prefix
   // unblocks using a shared workspace across envs.
   env_prefix = "${local.env}-"
+  // Base workspace directory under which to create resources in the workspace for the current MLOps project
+  // We assume the service principal used to deploy resources has CAN MANAGE permissions on directory
+  // You may need to modify this value if you'd like to use a different directory for per-project resources
+  mlflow_experiment_parent_dir = "{{cookiecutter.mlflow_experiment_parent_dir}}-${local.env}"
   // User group to give read permissions for the batch inference and model training jobs
   read_user_group = "{{cookiecutter.read_user_group}}"
 }

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/staging/provider.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/staging/provider.tf
@@ -3,7 +3,7 @@ terraform {
   // The `backend` block below configures the azurerm backend
   // (docs:
   // https://www.terraform.io/language/settings/backends/azurerm and
-  // https://docs.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage)
+  // https://learn.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage)
   // for storing Terraform state in Azure Blob Storage.
   // You can run the setup scripts in mlops-setup-scripts/terraform to provision the Azure Blob Storage container
   // referenced below and store appropriate credentials for accessing the container from CI/CD.

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/staging/training-job.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/staging/training-job.tf
@@ -16,7 +16,7 @@ resource "databricks_job" "model_training_job" {
     {% if cookiecutter.include_feature_store == "yes" %}notebook_task {
       notebook_path = "{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore"
       base_parameters = {
-        env                = "${local.env}"
+        env                = local.env
         training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         experiment_name    = databricks_mlflow_experiment.experiment.name
         model_name         = "${local.env_prefix}{{cookiecutter.model_name}}"

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/staging/training-job.tf
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/terraform/staging/training-job.tf
@@ -16,6 +16,7 @@ resource "databricks_job" "model_training_job" {
     {% if cookiecutter.include_feature_store == "yes" %}notebook_task {
       notebook_path = "{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore"
       base_parameters = {
+        env                = "${local.env}"
         training_data_path = "/databricks-datasets/nyctaxi-with-zipcodes/subsampled"
         experiment_name    = databricks_mlflow_experiment.experiment.name
         model_name         = "${local.env_prefix}{{cookiecutter.model_name}}"

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore.py
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore.py
@@ -6,7 +6,7 @@
 # It is configured and can be executed as a training-job.tf job defined under ``{{cookiecutter.project_name}}/terraform``
 #
 # Parameters:
-# * env (required):                 - Environment the notebook is run in (dev, staging, or prod). Defaults to "dev".
+# * env (required):                 - Environment the notebook is run in (staging, or prod). Defaults to "staging".
 # * training_data_path (required)   - Path to the training data.
 # * experiment_name (required)      - MLflow experiment name for the training runs. Will be created if it doesn't exist.
 # * model_name (required)           - MLflow registered model name to use for the trained model. Will be created if it
@@ -21,7 +21,7 @@
 # Provide them via DB widgets or notebook arguments.
 
 # Notebook Environment
-dbutils.widgets.dropdown("env", "dev", ["dev", "staging", "prod"], "Environment Name")
+dbutils.widgets.dropdown("env", "staging", ["staging", "prod"], "Environment Name")
 env = dbutils.widgets.get("env")
 
 # Path to the Hive-registered Delta table containing the training data.

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore.py
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore.py
@@ -43,6 +43,16 @@ dbutils.widgets.text(
     "model_name", "{{cookiecutter.model_name}}-test", label="Model Name"
 )
 
+# Pickup features table name
+dbutils.widgets.text(
+    "pickup_features_table", "feature_store_taxi_example.trip_pickup_features", label="Pickup Features Table"
+)
+
+# Dropoff features table name
+dbutils.widgets.text(
+    "dropoff_features_table", "feature_store_taxi_example.trip_dropoff_features", label="Dropoff Features Table"
+)
+
 # COMMAND ----------
 # DBTITLE 1,Define input and output variables
 
@@ -137,8 +147,8 @@ display(taxi_data)
 from databricks.feature_store import FeatureLookup
 import mlflow
 
-pickup_features_table = "feature_store_taxi_example.trip_pickup_features"
-dropoff_features_table = "feature_store_taxi_example.trip_dropoff_features"
+pickup_features_table = dbutils.widgets.get("pickup_features_table")
+dropoff_features_table = dbutils.widgets.get("dropoff_features_table")
 
 pickup_feature_lookups = [
     FeatureLookup(

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore.py
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/training/notebooks/TrainWithFeatureStore.py
@@ -6,7 +6,7 @@
 # It is configured and can be executed as a training-job.tf job defined under ``{{cookiecutter.project_name}}/terraform``
 #
 # Parameters:
-#
+# * env (required):                 - Environment the notebook is run in (dev, staging, or prod). Defaults to "dev".
 # * training_data_path (required)   - Path to the training data.
 # * experiment_name (required)      - MLflow experiment name for the training runs. Will be created if it doesn't exist.
 # * model_name (required)           - MLflow registered model name to use for the trained model. Will be created if it
@@ -20,6 +20,10 @@
 # List of input args needed to run this notebook as a job.
 # Provide them via DB widgets or notebook arguments.
 
+# Notebook Environment
+dbutils.widgets.dropdown("env", "dev", ["dev", "staging", "prod"], "Environment Name")
+env = dbutils.widgets.get("env")
+
 # Path to the Hive-registered Delta table containing the training data.
 dbutils.widgets.text(
     "training_data_path",
@@ -30,11 +34,11 @@ dbutils.widgets.text(
 # MLflow experiment name.
 dbutils.widgets.text(
     "experiment_name",
-    "/{{cookiecutter.project_name}}/{{cookiecutter.experiment_base_name}}-test",
+    f"/{{cookiecutter.mlflow_experiment_parent_dir}}-{env}/{{cookiecutter.experiment_base_name}}-test",
     label="MLflow experiment name",
 )
 
-# MLflow registered model name to use for the trained mode..
+# MLflow registered model name to use for the trained mode.
 dbutils.widgets.text(
     "model_name", "{{cookiecutter.model_name}}-test", label="Model Name"
 )

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/training/profiles/databricks-dev.yaml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/training/profiles/databricks-dev.yaml
@@ -1,12 +1,12 @@
 # This profile contains config overrides for model development on Databricks
 experiment:
-  name: "/{{cookiecutter.experiment_base_name}}-dev"
+  name: "/dev-{{cookiecutter.experiment_base_name}}"
 
 # Set the registry server URI. This property is especially useful if you have a registry
 # server that’s different from the tracking server.
 model_registry:
   # Specify the MLflow registered model name under which to register model versions
-  model_name: "{{cookiecutter.model_name}}-dev"
+  model_name: "dev-{{cookiecutter.model_name}}"
 
 # Override the default train / validation / test dataset split ratios
 SPLIT_RATIOS: [0.75, 0.125, 0.125]


### PR DESCRIPTION
As part of the single-workspace compatibility, we renamed the parent directory to include an environment suffix but did not update this for experiment references, especially in the feature store notebook. We also simplify some of the workflows and fix input/output pairs.