### PR TITLE
Fix model deployment

### DIFF
--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/deploy-model-prod.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/deploy-model-prod.yml
@@ -38,4 +38,4 @@ jobs:
           MLFLOW_TRACKING_URI: databricks
         run: |
           pip install mlflow
-          python steps/deploy.py {% raw %}"${{ github.event.inputs.modelUri }}"{% endraw %} "prod"
+          python {{cookiecutter.project_name}}/deployment/model_deployment/deploy.py {% raw %}"${{ github.event.inputs.modelUri }}"{% endraw %} "prod"

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/deploy-model-staging.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/workflows/deploy-model-staging.yml
@@ -38,4 +38,4 @@ jobs:
           MLFLOW_TRACKING_URI: databricks
         run: |
           pip install mlflow
-          python steps/deploy.py {% raw %}"${{ github.event.inputs.modelUri }}"{% endraw %} "staging"
+          python {{cookiecutter.project_name}}/deployment/model_deployment/deploy.py {% raw %}"${{ github.event.inputs.modelUri }}"{% endraw %} "staging"

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/deployment/model_deployment/deploy.py
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/deployment/model_deployment/deploy.py
@@ -1,6 +1,9 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).parent.parent.parent.resolve()))
 from utils import get_deployed_model_stage_for_env
 from mlflow.tracking import MlflowClient
-import sys
 
 
 def deploy(model_uri, env):


### PR DESCRIPTION
The model deployment was broken due to model layout change. Found by 
@niall-turbitt https://docs.google.com/document/d/1ChQrfnRxN2CAhECX7xJZw_tmu8PoweI9AlLqgx67Tmk/edit#

The change is to update github action to correctly call deploy and fix the import of utils.

---

I'm not importing "{{cookiecutter.project_name}}.utils" because currently there's no guarantee that the project_name is also a valid package name.(For example, the "mlops-azure-cuj" is not a valid package name)

After I added the `__init__` files, the relative import of "../.." works on my laptop but doesn't work for github actions(maybe because of the current work directory).

I have to use absolute path to import utils and it's working. 

---

Tested on CUJ project. The CUJ deployment was also broken after the layout change yesterday and I didn't notice it. Now it's fixed. https://github.com/databricks/mlops-azure-cuj/actions/runs/4431460872/jobs/7774443532

This is the change made in CUJ project https://github.com/databricks/mlops-azure-cuj/pull/74/files/f0f4df8dec32780fc2a6bd5f317e637a13eac865..1034207c3c9547c825a8bfeaa4e717ad9da39d27
 