### PR TITLE
Exit notebook without running model validation if feature store is used

### DIFF
--- a/tests/test_create_project.py
+++ b/tests/test_create_project.py
@@ -125,7 +125,7 @@ def test_markdown_links(generated_project_dir):
     markdown_checker_configs(generated_project_dir)
     subprocess.run(
         """
-        npm install -g markdown-link-check
+        npm install -g markdown-link-check@3.10.3
         find . -name \*.md -print0 | xargs -0 -n1 markdown-link-check -c ./checker-config.json
         """,
         shell=True,

--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/validation/notebooks/ModelValidation.py
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name}}/validation/notebooks/ModelValidation.py
@@ -65,6 +65,13 @@ dbutils.widgets.text("model_version", "", "Candidate Model Version")
 
 # COMMAND ----------
 
+{% if cookiecutter.include_feature_store == "yes" %}
+print(
+    "Currently model validation is not supported for models registered with feature store. Please refer to "
+    "issue https://github.com/databricks/mlops-stack/issues/70 for more details."
+)
+dbutils.notebook.exit(0){% endif %}
+
 import sys
 
 sys.path.append("..")


### PR DESCRIPTION
As title.

We don't want to run model validation with feature store packaged models before this issue is resolved. https://github.com/databricks/mlops-stack/issues/70