### PR TITLE
Add env prefix to batch inference output table name

### DIFF
--- a/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name_alphanumeric_underscore}}/databricks-resources/batch-inference-workflow-resource.yml
+++ b/{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{cookiecutter.project_name_alphanumeric_underscore}}/databricks-resources/batch-inference-workflow-resource.yml
@@ -24,7 +24,7 @@ resources:
               env: ${bundle.environment}
               {% if cookiecutter.include_feature_store == "yes" %}input_table_name: hive_metastore.default.taxi_scoring_sample_feature_store_inference_input
               {%- else -%}input_table_name: taxi_scoring_sample{% endif %}
-              output_table_name: {{cookiecutter.project_name_alphanumeric_underscore}}_predictions
+              output_table_name: ${bundle.environment}-{{cookiecutter.project_name_alphanumeric_underscore}}_predictions
               model_name: ${var.model_name}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}


### PR DESCRIPTION
If the staging env and dev env are referring to the same workspace, the staging batch inference workflow and the dev batch inference workflow could try to write to the same table at the same time and throw concurrent modification error.

To avoid concurrent modification between different workflows, we want to add the env prefix to the output table.