### PR TITLE
update docs to remove cookiecutter and add asset bundle templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ To create a new project, run:
 
 This will prompt for parameters for project initialization. Some of these parameters are required to get started:
  * ``input_project_name``: name of the current project
- * ``input_root_dir``: name of the root directory. The root directory name should be specified if monorepo will be used for the project. 
-   Otherwise, user can use the name of the current project as root directory name.
+ * ``input_root_dir``: name of the root directory. It is recommended to use the name of the current project as the root directory name, except in the case of a monorepo with other projects where the name of the monorepo should be used instead.
  * ``input_cloud``: Cloud provider you use with Databricks (AWS, Azure, or GCP)
  * ``input_cicd_platform`` : CI/CD platform of choice (GitHub Actions or GitHub Actions for GitHub Enterprise Servers or Azure DevOps)
 
@@ -173,12 +172,12 @@ of the example project:
 ```
 # Note: update MLOPS_STACK_PATH to the path to your local checkout of the stack
 MLOPS_STACK_PATH=~/mlops-stack
-databricks "$MLOPS_STACK_PATH" --config-file "$MLOPS_STACK_PATH/tests/example-project-configs/azure/azure-devops.json"
+databricks bundle init "$MLOPS_STACK_PATH" --config-file "$MLOPS_STACK_PATH/tests/example-project-configs/azure/azure-devops.json"
 ```
 
 To create an example AWS project, using GitHub Actions for CI/CD, run:
 ```
 # Note: update MLOPS_STACK_PATH to the path to your local checkout of the stack
 MLOPS_STACK_PATH=~/mlops-stack
-databricks "$MLOPS_STACK_PATH" --config-file "$MLOPS_STACK_PATH/tests/example-project-configs/aws/aws-github.json"
+databricks bundle init "$MLOPS_STACK_PATH" --config-file "$MLOPS_STACK_PATH/tests/example-project-configs/aws/aws-github.json"
 ```

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ structure defined in the default stack.
 
 ### Prerequisites
  - Python 3.8+
- - [Databricks asset bundle templates](https://docs.databricks.com/en/dev-tools/bundles/templates.html)
+ - [Databricks CLI](https://docs.databricks.com/en/dev-tools/cli/databricks-cli.html) >= v0.203.2
 
+[Databricks CLI](https://docs.databricks.com/en/dev-tools/cli/databricks-cli.html) v0.203.2 contains [Databricks asset bundle templates](https://docs.databricks.com/en/dev-tools/bundles/templates.html) for the purpose of project creation.
 Databricks asset bundle is in private preview. Please contact a Databricks representative for more information.
 
 ### Starting a new project

--- a/README.md
+++ b/README.md
@@ -35,40 +35,38 @@ structure defined in the default stack.
 
 ### Prerequisites
  - Python 3.8+
- - [Cookiecutter Python package](http://cookiecutter.readthedocs.org/en/latest/installation.html) >= 2.1.0: This can be installed with pip:
+ - [Databricks asset bundle templates](https://docs.databricks.com/en/dev-tools/bundles/templates.html)
 
-``` bash
-$ pip install 'cookiecutter>=2.1.0'
-```
+Databricks asset bundle is in private preview. Please contact a Databricks representative for more information.
 
 ### Starting a new project
 
 To create a new project, run:
 
-    cookiecutter https://github.com/databricks/mlops-stack
+    databricks bundle init https://github.com/databricks/mlops-stack
 
 This will prompt for parameters for project initialization. Some of these parameters are required to get started:
- * ``project_name``: name of the current project
- * ``root_dir__update_if_you_intend_to_use_monorepo``: name of the root directory. The root directory name should be specified if monorepo will be used for the project. 
-   Otherwise, user can leave it blank to use the name of the current project as root directory name.
- * ``cloud``: Cloud provider you use with Databricks (AWS, Azure, or GCP)
- * ``cicd_platform`` : CI/CD platform of choice (GitHub Actions or GitHub Actions for GitHub Enterprise Servers or Azure DevOps)
+ * ``input_project_name``: name of the current project
+ * ``input_root_dir``: name of the root directory. The root directory name should be specified if monorepo will be used for the project. 
+   Otherwise, user can use the name of the current project as root directory name.
+ * ``input_cloud``: Cloud provider you use with Databricks (AWS, Azure, or GCP)
+ * ``input_cicd_platform`` : CI/CD platform of choice (GitHub Actions or GitHub Actions for GitHub Enterprise Servers or Azure DevOps)
 
 Others must be correctly specified for CI/CD to work, and so can be left at their default values until you're
 ready to productionize a model. We recommend specifying any known parameters upfront (e.g. if you know
-``databricks_staging_workspace_host``, it's better to specify it upfront):
+``input_databricks_staging_workspace_host``, it's better to specify it upfront):
 
- * ``databricks_staging_workspace_host``: URL of staging Databricks workspace, used to run CI tests on PRs and preview config changes before they're deployed to production.
+ * ``input_databricks_staging_workspace_host``: URL of staging Databricks workspace, used to run CI tests on PRs and preview config changes before they're deployed to production.
    We encourage granting data scientists working on the current ML project non-admin (read) access to this workspace,
    to enable them to view and debug CI test results
- * ``databricks_prod_workspace_host``: URL of production Databricks workspace. We encourage granting data scientists working on the current ML project non-admin (read) access to this workspace,
+ * ``input_databricks_prod_workspace_host``: URL of production Databricks workspace. We encourage granting data scientists working on the current ML project non-admin (read) access to this workspace,
    to enable them to view production job status and see job logs to debug failures.
- * ``default_branch``: Name of the default branch, where the prod and staging ML resources are deployed from and the latest ML code is staged.
- * ``release_branch``: Name of the release branch. The production jobs (model training, batch inference) defined in this
+ * ``input_default_branch``: Name of the default branch, where the prod and staging ML resources are deployed from and the latest ML code is staged.
+ * ``input_release_branch``: Name of the release branch. The production jobs (model training, batch inference) defined in this
     repo pull ML code from this branch.
- * ``read_user_group``: User group name to give READ permissions to for project resources (ML jobs, integration test job runs, and machine learning resources). A group with this name must exist in both the staging and prod workspaces. Defaults to "users", which grants read permission to all users in the staging/prod workspaces. You can specify a custom group name e.g. to restrict read permissions to members of the team working on the current ML project.
- * ``include_feature_store``: If selected, will provide [Databricks Feature Store](https://docs.databricks.com/machine-learning/feature-store/index.html) stack components including: project structure and sample feature Python modules, feature engineering notebooks, ML resource configs to provision and manage Feature Store jobs, and automated integration tests covering feature engineering and training.
- * ``include_mlflow_recipes``: If selected, will provide [MLflow Recipes](https://mlflow.org/docs/latest/recipes.html) stack components, dividing the training pipeline into configurable steps and profiles.
+ * ``input_read_user_group``: User group name to give READ permissions to for project resources (ML jobs, integration test job runs, and machine learning resources). A group with this name must exist in both the staging and prod workspaces. Defaults to "users", which grants read permission to all users in the staging/prod workspaces. You can specify a custom group name e.g. to restrict read permissions to members of the team working on the current ML project.
+ * ``input_include_feature_store``: If selected, will provide [Databricks Feature Store](https://docs.databricks.com/machine-learning/feature-store/index.html) stack components including: project structure and sample feature Python modules, feature engineering notebooks, ML resource configs to provision and manage Feature Store jobs, and automated integration tests covering feature engineering and training.
+ * ``input_include_mlflow_recipes``: If selected, will provide [MLflow Recipes](https://mlflow.org/docs/latest/recipes.html) stack components, dividing the training pipeline into configurable steps and profiles.
  
 
 See the generated ``README.md`` for next steps!
@@ -84,7 +82,7 @@ production model serving endpoints.
 
 However, you can run the stack against just a single workspace, against a dev and
 staging/prod workspace, etc. Just supply the same workspace URL for
-`databricks_staging_host` and `databricks_prod_host`. If you go this route, we
+`input_databricks_staging_workspace_host` and `input_databricks_prod_workspace_host`. If you go this route, we
 recommend using different service principals to manage staging vs prod resources,
 to ensure that CI workloads run in staging cannot interfere with production resources.
 
@@ -92,14 +90,14 @@ to ensure that CI workloads run in staging cannot interfere with production reso
 Yes. Currently, you can instantiate a new project from the stack and copy relevant components
 into your existing project to productionize it. The stack is modularized, so
 you can e.g. copy just the GitHub Actions workflows under `.github` or ML resource configs
- under `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources` 
-and `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{template `project_name_alphanumeric_underscore` .}}/bundle.yml` into your existing project.
+ under ``{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources`` 
+and ``{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/bundle.yml`` into your existing project.
 
 ### Can I adopt individual components of the stack?
-For this use case, we recommend instantiating the full stack via `cookiecutter`
+For this use case, we recommend instantiating the full stack via [Databricks asset bundle templates](https://docs.databricks.com/en/dev-tools/bundles/templates.html) 
 and copying the relevant stack subdirectories. For example, all ML resource configs
-are defined under `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources`
-and `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{template `project_name_alphanumeric_underscore` .}}/bundle.yml`, while CI/CD is defined e.g. under `.github`
+are defined under ``{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources``
+and ``{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/bundle.yml``, while CI/CD is defined e.g. under `.github`
 if using GitHub Actions, or under `.azure` if using Azure DevOps.
 
 ### Can I customize this stack?
@@ -124,9 +122,9 @@ Please provide feedback (bug reports, feature requests, etc) via GitHub issues.
 We welcome community contributions. For substantial changes, we ask that you first file a GitHub issue to facilitate
 discussion, before opening a pull request.
 
-This stack is implemented as a [cookiecutter template](https://cookiecutter.readthedocs.io/en/stable/)
+This stack is implemented as a [Databricks asset bundle template](https://docs.databricks.com/en/dev-tools/bundles/templates.html)
 that generates new projects given user-supplied parameters. Parametrized project code can be found under
-the `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}` directory.
+the `{{.input_root_dir}}` directory.
 
 ### Installing development requirements
 
@@ -139,7 +137,7 @@ dependencies listed in `dev-requirements.txt`:
 
 ### Running the tests
 **NOTE**: This section is for open-source developers contributing to the default stack
-in this repo.  If you are working on an ML project using the stack (e.g. if you ran `cookiecutter`
+in this repo.  If you are working on an ML project using the stack (e.g. if you ran `databricks bundle init`
 to start a new project), see the `README.md` within your generated
 project directory for detailed instructions on how to make and test changes.
 
@@ -174,12 +172,12 @@ of the example project:
 ```
 # Note: update MLOPS_STACK_PATH to the path to your local checkout of the stack
 MLOPS_STACK_PATH=~/mlops-stack
-cookiecutter "$MLOPS_STACK_PATH" --config-file "$MLOPS_STACK_PATH/tests/example-project-configs/azure/azure-devops.yaml" --no-input --overwrite-if-exists
+databricks "$MLOPS_STACK_PATH" --config-file "$MLOPS_STACK_PATH/tests/example-project-configs/azure/azure-devops.json"
 ```
 
 To create an example AWS project, using GitHub Actions for CI/CD, run:
 ```
 # Note: update MLOPS_STACK_PATH to the path to your local checkout of the stack
 MLOPS_STACK_PATH=~/mlops-stack
-cookiecutter "$MLOPS_STACK_PATH" --config-file "$MLOPS_STACK_PATH/tests/example-project-configs/aws/aws-github.yaml" --no-input --overwrite-if-exists
+databricks "$MLOPS_STACK_PATH" --config-file "$MLOPS_STACK_PATH/tests/example-project-configs/aws/aws-github.json"
 ```

--- a/stack-customization.md
+++ b/stack-customization.md
@@ -10,6 +10,8 @@ However, in many cases you may need to customize the stack, for example if:
 * You'd like to run extra checks/tests in CI/CD besides the ones supported out of the box
 * You're using an ML code structure built in-house
 
+For more information about generating a project using Databricks asset bundle templates, please refer to [link](https://docs.databricks.com/en/dev-tools/bundles/templates.html).
+
 ## Creating a custom stack
 
 **Note**: the development loop for your custom stack is the same as for iterating on the
@@ -31,12 +33,12 @@ Otherwise, you'll need to translate the workflows under `.github/` to the CI pro
 choice.
 
 ### Update stack parameters
-Update parameters in your fork as needed in `cookiecutter.json`. Pruning the set of
+Update parameters in your fork as needed in `databricks_template_schema.json` and update corresponding template variable in `library/template_variables.tmpl`. Pruning the set of
 parameters makes it easier for data scientists to start new projects, at the cost of reduced flexibility.
 
 For example, you may have a fixed set of staging & prod Databricks workspaces (or use a single staging & prod workspace), so the
-`databricks_staging_workspace_host` and `databricks_prod_workspace_host` parameters may be unnecessary. You may
-also run all of your ML pipelines on a single cloud, in which case the `cloud` parameter is unnecessary.
+`input_databricks_staging_workspace_host` and `input_databricks_prod_workspace_host` parameters may be unnecessary. You may
+also run all of your ML pipelines on a single cloud, in which case the `input_cloud` parameter is unnecessary.
 
 The easiest way to prune parameters and replace them with hardcoded values is to follow
 the [contributor guide](README.md#previewing-stack-changes) to generate an example project with
@@ -51,35 +53,34 @@ to fill out, or remove and replace the use of MLflow Recipes if you expect data 
 types that are currently unsupported by MLflow Recipes.
 
 If you customize this component, you can still use the CI/CD and ML resource components to build production ML pipelines, as long as you provide ML
-notebooks with the expected interface for model training and inference under
-`{cookiecutter_project_name}}/notebooks/`. See code comments in files under
-`{cookiecutter_project_name}}/notebooks/` for the expected interface & behavior of these notebooks.
+notebooks with the expected interface. For example, model training under ``template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/notebooks/`` and inference under
+``template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/deployment/batch_inference/notebooks/``. See code comments in the notebook files for the expected interface & behavior of these notebooks.
 
-You may also want to update developer-facing docs under `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-developer-guide.md`
-or `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs/ml-developer-guide-fs.md`, which will be read by users of your stack.
+You may also want to update developer-facing docs under `template/{{.input_root_dir}}/docs/ml-developer-guide.md`
+or `template/{{.input_root_dir}}/docs/ml-developer-guide-fs.md`, which will be read by users of your stack.
 
 ### CI/CD workflows
 The default stack currently has the following sub-components for CI/CD:
-* CI/CD workflow logic defined under `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.github/` for testing and deploying ML code and models
-* Automated scripts and docs for setting up CI/CD under `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/.mlops-setup-scripts/`
+* CI/CD workflow logic defined under `template/{{.input_root_dir}}/.github/` for testing and deploying ML code and models
+* Automated scripts and docs for setting up CI/CD under `template/{{.input_root_dir}}/.mlops-setup-scripts/`
 * Logic to trigger model deployment through REST API calls to your CD system, when model training completes.
-  This logic is currently captured in `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{template `project_name_alphanumeric_underscore` .}}/deployment/model_deployment/notebooks/TriggerModelDeploy.py`
+  This logic is currently captured in ``template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/deployment/model_deployment/notebooks/TriggerModelDeploy.py``
 
 ### ML resource configs
-Root ML resource config file can be found as ``{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{template `project_name_alphanumeric_underscore` .}}/bundle.yml``. 
+Root ML resource config file can be found as ``{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/bundle.yml``. 
 It defines the ML config resources to be included and workspace host for each environment.
 
 ML resource configs (databricks CLI bundles code definitions of ML jobs, experiments, models etc) can be found under 
-``{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources``, along with docs.
+``template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources``, along with docs.
 
 You can update this component to customize the default ML pipeline structure for new ML projects in your organization,
 e.g. add additional model inference jobs or modify the default instance type used in ML jobs.
 
 When updating this component, you may want to update developer-facing docs in
-`{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/README.md`.
+``template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/README.md``.
 
 ### Docs
 After making stack customizations, make any changes needed to
-the stack docs under `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/docs` and in the main README
-(`{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/README.md`) to reflect any updates you've made to the stack.
-For example, you may want to include a link to your custom stack in `{{cookiecutter.root_dir__update_if_you_intend_to_use_monorepo}}/README.md`.
+the stack docs under `template/{{.input_root_dir}}/docs` and in the main README
+(`template/{{.input_root_dir}}/README.md`) to reflect any updates you've made to the stack.
+For example, you may want to include a link to your custom stack in `template/{{.input_root_dir}}/README.md`.


### PR DESCRIPTION
As title. 
Update docs.

migration plan https://docs.google.com/document/d/19MOK9o-f0A_-NMmxC1cJGQSQ2WkJXZ4vXQZ4plu-tng/edit