### PR TITLE
rename environments to targets and use -t instead of -e in bundle commands

### DIFF
--- a/stack-customization.md
+++ b/stack-customization.md
@@ -68,7 +68,7 @@ The default stack currently has the following sub-components for CI/CD:
 
 ### ML resource configs
 Root ML resource config file can be found as ``{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/bundle.yml``. 
-It defines the ML config resources to be included and workspace host for each environment.
+It defines the ML config resources to be included and workspace host for each target(environment).
 
 ML resource configs (databricks CLI bundles code definitions of ML jobs, experiments, models etc) can be found under 
 ``template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources``, along with docs.

--- a/stack-customization.md
+++ b/stack-customization.md
@@ -68,7 +68,7 @@ The default stack currently has the following sub-components for CI/CD:
 
 ### ML resource configs
 Root ML resource config file can be found as ``{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/bundle.yml``. 
-It defines the ML config resources to be included and workspace host for each target(environment).
+It defines the ML config resources to be included and workspace host for each deployment target.
 
 ML resource configs (databricks CLI bundles code definitions of ML jobs, experiments, models etc) can be found under 
 ``template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources``, along with docs.

--- a/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-bundle-cicd.yml.tmpl
+++ b/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-bundle-cicd.yml.tmpl
@@ -49,9 +49,9 @@ stages:
 
     # Validate bundle to be deployed to the staging workspace
     - script: |
-        databricks bundle validate -e staging  
+        databricks bundle validate -t staging
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: 'Validate bundle for staging environment'
+      displayName: 'Validate bundle for staging target(environment)'
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -77,9 +77,9 @@ stages:
 
     # Validate bundle to be deployed to the staging workspace
     - script: |
-        databricks bundle validate -e prod  
+        databricks bundle validate -t prod
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Validate bundle for staging environment 
+      displayName: Validate bundle for staging target(environment)
       env:
         ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
@@ -118,9 +118,9 @@ stages:
 
     # Validate bundle to be deployed to the Staging workspace
     - script: |
-        databricks bundle validate -e staging  
+        databricks bundle validate -t staging
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Validate bundle for staging environment 
+      displayName: Validate bundle for staging target(environment)
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -128,9 +128,9 @@ stages:
 
     # Deploy bundle to Staging workspace
     - script: |
-        databricks bundle deploy -e staging
+        databricks bundle deploy -t staging
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: 'Deploy bundle to staging environment'
+      displayName: 'Deploy bundle to staging target(environment)'
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -169,9 +169,9 @@ stages:
 
     # Validate bundle to be deployed to the prod workspace
     - script: |
-        databricks bundle validate -e prod  
+        databricks bundle validate -t prod
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Validate bundle for prod environment 
+      displayName: Validate bundle for prod target(environment)
       env:
         ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
@@ -179,9 +179,9 @@ stages:
 
     # Deploy bundle to prod workspace
     - script: |
-        databricks bundle deploy -e prod
+        databricks bundle deploy -t prod
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Deploy bundle to prod environment
+      displayName: Deploy bundle to prod target(environment)
       env:
         ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)

--- a/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-bundle-cicd.yml.tmpl
+++ b/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-bundle-cicd.yml.tmpl
@@ -51,7 +51,7 @@ stages:
     - script: |
         databricks bundle validate -t staging
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: 'Validate bundle for staging target(environment)'
+      displayName: 'Validate bundle for staging'
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -79,7 +79,7 @@ stages:
     - script: |
         databricks bundle validate -t prod
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Validate bundle for staging target(environment)
+      displayName: 'Validate bundle for staging'
       env:
         ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
@@ -120,7 +120,7 @@ stages:
     - script: |
         databricks bundle validate -t staging
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Validate bundle for staging target(environment)
+      displayName: 'Validate bundle for staging'
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -130,7 +130,7 @@ stages:
     - script: |
         databricks bundle deploy -t staging
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: 'Deploy bundle to staging target(environment)'
+      displayName: 'Deploy bundle to staging'
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -171,7 +171,7 @@ stages:
     - script: |
         databricks bundle validate -t prod
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Validate bundle for prod target(environment)
+      displayName: 'Validate bundle for prod'
       env:
         ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)
@@ -181,7 +181,7 @@ stages:
     - script: |
         databricks bundle deploy -t prod
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Deploy bundle to prod target(environment)
+      displayName: 'Deploy bundle to prod'
       env:
         ARM_TENANT_ID: $(PROD_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(PROD_AZURE_SP_APPLICATION_ID)

--- a/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-tests-ci.yml.tmpl
+++ b/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-tests-ci.yml.tmpl
@@ -76,9 +76,9 @@ jobs:
 
     # Validate bundle to be deployed to the staging workspace
     - script: |
-        databricks bundle validate -e test  
+        databricks bundle validate -t test
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Validate bundle for test environment in staging workspace 
+      displayName: Validate bundle for test target(environment) in staging workspace
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -86,20 +86,20 @@ jobs:
 
     # Deploy bundle to staging workspace
     - script: |
-        databricks bundle deploy -e test
+        databricks bundle deploy -t test
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Deploy bundle to test environment in staging workspace
+      displayName: Deploy bundle to test target(environment) in staging workspace
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
         ARM_CLIENT_SECRET: $(STAGING_AZURE_SP_CLIENT_SECRET)          
 
     {{ if (eq .input_include_feature_store `yes`) }}
-    # Run Feature Engineering Workflow for Test Environment in Staging Workspace
+    # Run Feature Engineering Workflow for test target(environment) in Staging Workspace
     - script: |
-        databricks bundle run write_feature_table_job -e test
+        databricks bundle run write_feature_table_job -t test
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Run Feature Engineering Workflow for Test Environment in Staging Workspace
+      displayName: Run Feature Engineering Workflow for test target(environment) in Staging Workspace
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -108,9 +108,9 @@ jobs:
     
     # Run model_training_job defined in bundle in the staging workspace
     - script: |
-        databricks bundle run model_training_job -e test
+        databricks bundle run model_training_job -t test
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Run training workflow for test environment in staging workspace
+      displayName: Run training workflow for test target(environment) in staging workspace
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)

--- a/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-tests-ci.yml.tmpl
+++ b/template/{{.input_root_dir}}/.azure/devops-pipelines/{{.input_project_name}}-tests-ci.yml.tmpl
@@ -78,7 +78,7 @@ jobs:
     - script: |
         databricks bundle validate -t test
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Validate bundle for test target(environment) in staging workspace
+      displayName: Validate bundle for test deployment target in staging workspace
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -88,18 +88,18 @@ jobs:
     - script: |
         databricks bundle deploy -t test
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Deploy bundle to test target(environment) in staging workspace
+      displayName: Deploy bundle to test deployment target in staging workspace
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
         ARM_CLIENT_SECRET: $(STAGING_AZURE_SP_CLIENT_SECRET)          
 
     {{ if (eq .input_include_feature_store `yes`) }}
-    # Run Feature Engineering Workflow for test target(environment) in Staging Workspace
+    # Run Feature Engineering Workflow for test deployment target in Staging Workspace
     - script: |
         databricks bundle run write_feature_table_job -t test
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Run Feature Engineering Workflow for test target(environment) in Staging Workspace
+      displayName: Run Feature Engineering Workflow for test deployment target in Staging Workspace
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)
@@ -110,7 +110,7 @@ jobs:
     - script: |
         databricks bundle run model_training_job -t test
       workingDirectory: {{template `project_name_alphanumeric_underscore` .}}
-      displayName: Run training workflow for test target(environment) in staging workspace
+      displayName: Run training workflow for test deployment target in staging workspace
       env:
         ARM_TENANT_ID: $(STAGING_AZURE_SP_TENANT_ID)
         ARM_CLIENT_ID: $(STAGING_AZURE_SP_APPLICATION_ID)

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-cd-prod.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-cd-prod.yml.tmpl
@@ -1,6 +1,6 @@
 # This GitHub workflow deploys Bundle resources (ML resource config and more)
 # defined under {{template `project_name_alphanumeric_underscore` .}}/databricks-resources/*
-# and {{template `project_name_alphanumeric_underscore` .}}/bundle.yml with prod environment configs,
+# and {{template `project_name_alphanumeric_underscore` .}}/bundle.yml with prod target(environment) configs,
 # when PRs are merged into the release branch
 name: Bundle Deployment for {{template `project_name` .}} Prod
 
@@ -30,11 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Prod Environment
+      - name: Validate Bundle For Prod Target(Environment)
         id: validate
         run: |
-          databricks bundle validate -e prod
-      - name: Deploy Bundle to Prod Environment
+          databricks bundle validate -t prod
+      - name: Deploy Bundle to Prod Target(Environment)
         id: deploy
         run: |
-          databricks bundle deploy -e prod
+          databricks bundle deploy -t prod

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-cd-prod.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-cd-prod.yml.tmpl
@@ -1,6 +1,6 @@
 # This GitHub workflow deploys Bundle resources (ML resource config and more)
 # defined under {{template `project_name_alphanumeric_underscore` .}}/databricks-resources/*
-# and {{template `project_name_alphanumeric_underscore` .}}/bundle.yml with prod target(environment) configs,
+# and {{template `project_name_alphanumeric_underscore` .}}/bundle.yml with prod deployment target configs,
 # when PRs are merged into the release branch
 name: Bundle Deployment for {{template `project_name` .}} Prod
 
@@ -30,11 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Prod Target(Environment)
+      - name: Validate Bundle For Prod
         id: validate
         run: |
           databricks bundle validate -t prod
-      - name: Deploy Bundle to Prod Target(Environment)
+      - name: Deploy Bundle to Prod
         id: deploy
         run: |
           databricks bundle deploy -t prod

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-cd-staging.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-cd-staging.yml.tmpl
@@ -1,6 +1,6 @@
 # This GitHub workflow deploys Bundle resources (ML resource config and more)
 # defined under {{template `project_name_alphanumeric_underscore` .}}/databricks-resources/*
-# and {{template `project_name_alphanumeric_underscore` .}}/bundle.yml with staging environment configs,
+# and {{template `project_name_alphanumeric_underscore` .}}/bundle.yml with staging target(environment) configs,
 # when PRs are merged into the default branch
 name: Bundle Deployment for {{template `project_name` .}} Staging
 
@@ -30,11 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Staging Environment
+      - name: Validate Bundle For Staging Target(Environment)
         id: validate
         run: |
-          databricks bundle validate -e staging
-      - name: Deploy Bundle to Staging Environment
+          databricks bundle validate -t staging
+      - name: Deploy Bundle to Staging Target(Environment)
         id: deploy
         run: |
-          databricks bundle deploy -e staging
+          databricks bundle deploy -t staging

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-cd-staging.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-cd-staging.yml.tmpl
@@ -1,6 +1,6 @@
 # This GitHub workflow deploys Bundle resources (ML resource config and more)
 # defined under {{template `project_name_alphanumeric_underscore` .}}/databricks-resources/*
-# and {{template `project_name_alphanumeric_underscore` .}}/bundle.yml with staging target(environment) configs,
+# and {{template `project_name_alphanumeric_underscore` .}}/bundle.yml with staging deployment target configs,
 # when PRs are merged into the default branch
 name: Bundle Deployment for {{template `project_name` .}} Staging
 
@@ -30,11 +30,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Staging Target(Environment)
+      - name: Validate Bundle For Staging
         id: validate
         run: |
           databricks bundle validate -t staging
-      - name: Deploy Bundle to Staging Target(Environment)
+      - name: Deploy Bundle to Staging
         id: deploy
         run: |
           databricks bundle deploy -t staging

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-ci.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-ci.yml.tmpl
@@ -33,7 +33,7 @@ jobs:
         with:
           ref: {{`${{ github.event.pull_request.head.sha || github.sha }}`}}
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Staging Environment
+      - name: Validate Bundle For Staging Target(Environment)
         id: validate
         env:
           {{ if (eq .input_cloud `aws`) -}}
@@ -44,7 +44,7 @@ jobs:
           ARM_CLIENT_SECRET: {{`${{ env.STAGING_ARM_CLIENT_SECRET }}`}}
           {{- end }}
         run: |
-          databricks bundle validate -e staging > ../validate_output.txt
+          databricks bundle validate -t staging > ../validate_output.txt
       - name: Create Comment with Bundle Configuration
         uses: actions/github-script@v6
         id: comment
@@ -77,7 +77,7 @@ jobs:
         with:
           ref: {{`${{ github.event.pull_request.head.sha || github.sha }}`}}
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Prod Environment
+      - name: Validate Bundle For Prod Target(Environment)
         id: validate
         env:
           {{ if (eq .input_cloud `aws`) -}}
@@ -88,7 +88,7 @@ jobs:
           ARM_CLIENT_SECRET: {{`${{ env.PROD_ARM_CLIENT_SECRET }}`}}
           {{- end }}
         run: |
-          databricks bundle validate -e prod > ../validate_output.txt
+          databricks bundle validate -t prod > ../validate_output.txt
       - name: Create Comment with Bundle Configuration
         uses: actions/github-script@v6
         id: comment

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-ci.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-bundle-ci.yml.tmpl
@@ -33,7 +33,7 @@ jobs:
         with:
           ref: {{`${{ github.event.pull_request.head.sha || github.sha }}`}}
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Staging Target(Environment)
+      - name: Validate Bundle For Staging
         id: validate
         env:
           {{ if (eq .input_cloud `aws`) -}}
@@ -77,7 +77,7 @@ jobs:
         with:
           ref: {{`${{ github.event.pull_request.head.sha || github.sha }}`}}
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Prod Target(Environment)
+      - name: Validate Bundle For Prod
         id: validate
         env:
           {{ if (eq .input_cloud `aws`) -}}

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests-fs.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests-fs.yml.tmpl
@@ -47,19 +47,19 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Test Environment in Staging Workspace
+      - name: Validate Bundle For Test Target(Environment) in Staging Workspace
         id: validate
         run: |
-          databricks bundle validate -e test
-      - name: Deploy Bundle to Test Environment in Staging Workspace
+          databricks bundle validate -t test
+      - name: Deploy Bundle to Test Target(Environment) in Staging Workspace
         id: deploy
         run: |
-          databricks bundle deploy -e test
-      - name: Run Feature Engineering Workflow for Test Environment in Staging Workspace
+          databricks bundle deploy -t test
+      - name: Run Feature Engineering Workflow for Test Target(Environment) in Staging Workspace
         id: feature_engineering
         run: |
-          databricks bundle run write_feature_table_job -e test
-      - name: Run Training Workflow for Test Environment in Staging Workspace
+          databricks bundle run write_feature_table_job -t test
+      - name: Run Training Workflow for Test Target(Environment) in Staging Workspace
         id: training
         run: |
-          databricks bundle run model_training_job -e test
+          databricks bundle run model_training_job -t test

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests-fs.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests-fs.yml.tmpl
@@ -47,19 +47,19 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Test Target(Environment) in Staging Workspace
+      - name: Validate Bundle For Test Deployment Target in Staging Workspace
         id: validate
         run: |
           databricks bundle validate -t test
-      - name: Deploy Bundle to Test Target(Environment) in Staging Workspace
+      - name: Deploy Bundle to Test Deployment Target in Staging Workspace
         id: deploy
         run: |
           databricks bundle deploy -t test
-      - name: Run Feature Engineering Workflow for Test Target(Environment) in Staging Workspace
+      - name: Run Feature Engineering Workflow for Test Deployment Target in Staging Workspace
         id: feature_engineering
         run: |
           databricks bundle run write_feature_table_job -t test
-      - name: Run Training Workflow for Test Target(Environment) in Staging Workspace
+      - name: Run Training Workflow for Test Deployment Target in Staging Workspace
         id: training
         run: |
           databricks bundle run model_training_job -t test

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests.yml.tmpl
@@ -42,15 +42,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Test Environment in Staging Workspace
+      - name: Validate Bundle For Test Target(Environment) in Staging Workspace
         id: validate
         run: |
-          databricks bundle validate -e test
-      - name: Deploy Bundle to Test Environment in Staging Workspace
+          databricks bundle validate -t test
+      - name: Deploy Bundle to Test Target(Environment) in Staging Workspace
         id: deploy
         run: |
-          databricks bundle deploy -e test
-      - name: Run Training Workflow for Test Environment in Staging Workspace
+          databricks bundle deploy -t test
+      - name: Run Training Workflow for Test Target(Environment) in Staging Workspace
         id: training
         run: |
-          databricks bundle run model_training_job -e test
+          databricks bundle run model_training_job -t test

--- a/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests.yml.tmpl
+++ b/template/{{.input_root_dir}}/.github/workflows/{{.input_project_name}}-run-tests.yml.tmpl
@@ -42,15 +42,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
       - uses: databricks/setup-cli@main
-      - name: Validate Bundle For Test Target(Environment) in Staging Workspace
+      - name: Validate Bundle For Test Deployment Target in Staging Workspace
         id: validate
         run: |
           databricks bundle validate -t test
-      - name: Deploy Bundle to Test Target(Environment) in Staging Workspace
+      - name: Deploy Bundle to Test Deployment Target in Staging Workspace
         id: deploy
         run: |
           databricks bundle deploy -t test
-      - name: Run Training Workflow for Test Target(Environment) in Staging Workspace
+      - name: Run Training Workflow for Test Deployment Target in Staging Workspace
         id: training
         run: |
           databricks bundle run model_training_job -t test

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/README.md.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/README.md.tmpl
@@ -58,7 +58,7 @@ Upon merging code into the release branch, the release branch content will be de
 To set up the databricks CLI using a Databricks personal access token, take the following steps:
 
 1. Follow [databricks CLI]({{ template `generate_doc_link` (map (pair "cloud" .input_cloud) (pair "path" "dev-tools/cli/databricks-cli.html")) }}) to download and set up the databricks CLI locally.
-2. Complete the `TODO` in `{{template `project_name_alphanumeric_underscore` .}}/databricks.yml` to add the dev workspace URI under `environments.dev.workspace.host`.
+2. Complete the `TODO` in `{{template `project_name_alphanumeric_underscore` .}}/databricks.yml` to add the dev workspace URI under `targets.dev.workspace.host`.
 3. [Create a personal access token]({{ template `generate_doc_link` (map (pair "cloud" .input_cloud) (pair "path" "dev-tools/auth.html#personal-access-tokens-for-users")) }})
   in your dev workspace and copy it.
 4. Set an env variable `DATABRICKS_TOKEN` with your Databricks personal access token in your terminal. For example, run `export DATABRICKS_TOKEN=dapi12345` if the access token is dapi12345.
@@ -138,43 +138,43 @@ new_cluster: &new_cluster
 resources:
   jobs:
     batch_inference_job:
-      name: ${bundle.environment}-{{template `project_name` .}}-batch-inference-job
+      name: ${bundle.target}-{{template `project_name` .}}-batch-inference-job
       tasks:
         - task_key: batch_inference_job
           <<: *new_cluster
           notebook_task:
             notebook_path: ../deployment/batch_inference/notebooks/BatchInference.py
             base_parameters:
-              env: ${bundle.environment}
+              env: ${bundle.target}
               input_table_name: batch_inference_input_table_name
               ...
 ```
 
-The example above defines a Databricks job with name `${bundle.environment}-{{template `project_name` .}}-batch-inference-job`
+The example above defines a Databricks job with name `${bundle.target}-{{template `project_name` .}}-batch-inference-job`
 that runs the notebook under `{{template `project_name_alphanumeric_underscore` .}}/deployment/batch_inference/notebooks/BatchInference.py` to regularly apply your ML model for batch inference. 
 
 At the start of the resource definition, we declared an anchor `new_cluster` that will be referenced and used later. For more information about anchors in yaml schema, please refer to the [yaml documentation](https://yaml.org/spec/1.2.2/#3222-anchors-and-aliases).
 
-We specify a `batch_inference_job` under `resources/jobs` to define a databricks workflow with internal key `batch_inference_job` and job name `{bundle.environment}-{{template `project_name` .}}-batch-inference-job`. 
+We specify a `batch_inference_job` under `resources/jobs` to define a databricks workflow with internal key `batch_inference_job` and job name `{bundle.target}-{{template `project_name` .}}-batch-inference-job`.
 The workflow contains a single task with task key `batch_inference_job`. The task runs notebook `../deployment/batch_inference/notebooks/BatchInference.py` with provided parameters `env` and `input_table_name` passing to the notebook.
 After setting up databricks CLI, you can run command `databricks bundle schema`  to learn more about databricks CLI bundles schema.
 
 The notebook_path is the relative path starting from the resource yaml file.
 
 ### Environment config based variables
-The `${bundle.environment}` will be replaced by the environment config name during the bundle deployment. For example, during the deployment of a `test` environment config, the job name will be
+The `${bundle.target}` will be replaced by the environment config name during the bundle deployment. For example, during the deployment of a `test` environment config, the job name will be
 `test-{{template `project_name` .}}-batch-inference-job`. During the deployment of the `staging` environment config, the job name will be
 `staging-{{template `project_name` .}}-batch-inference-job`.
 
 
-To use different values based on different environment, you can use bundle variables based on the given environment, for example,
+To use different values based on different environment, you can use bundle variables based on the given target, for example,
 ```$xslt
 variables:
   batch_inference_input_table: 
     description: The table name to be used for input to the batch inference workflow.
     default: input_table
 
-environments:
+targets:
   dev:
     variables:
       batch_inference_input_table: dev_table
@@ -193,14 +193,14 @@ new_cluster: &new_cluster
 resources:
   jobs:
     batch_inference_job:
-      name: ${bundle.environment}-{{template `project_name` .}}-batch-inference-job
+      name: ${bundle.target}-{{template `project_name` .}}-batch-inference-job
       tasks:
         - task_key: batch_inference_job
           <<: *new_cluster
           notebook_task:
             notebook_path: ../deployment/batch_inference/notebooks/BatchInference.py
             base_parameters:
-              env: ${bundle.environment}
+              env: ${bundle.target}
               input_table_name: ${var.batch_inference_input_table}
               ...
 ```

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/README.md.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/README.md.tmpl
@@ -26,20 +26,20 @@ ML Resource Configurations in this directory:
  - model definition and experiment definition (`{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/ml-artifacts-resource.yml`)
 
 
-### Environment Config & CI/CD integration
-The ML resources can be deployed to databricks workspace based on the databricks CLI bundles environment config. 
-Different environment configs share the general ML resource configurations with added ability to specify environment specific values (workspace URI, model name, jobs notebook parameters, etc).
+### Deployment Config & CI/CD integration
+The ML resources can be deployed to databricks workspace based on the databricks CLI bundles deployment config.
+Deployment configs of different deployment targets share the general ML resource configurations with added ability to specify deployment target specific values (workspace URI, model name, jobs notebook parameters, etc).
 
-This project ships with CI/CD workflows for developing and deploying ML resource configurations based on environment config.
+This project ships with CI/CD workflows for developing and deploying ML resource configurations based on deployment config.
 
-| Environment | Description                                                                                                                                                                                                                           | Databricks Workspace | Model Name                          | Experiment Name                                |
+| Deployment Target | Description                                                                                                                                                                                                                           | Databricks Workspace | Model Name                          | Experiment Name                                |
 |-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|-------------------------------------|------------------------------------------------|
-| dev         | The `dev` environment is used by ML engineers to deploy ML resources to development workspace with `dev` environment configs. The config is for ML project development purposes.                                                           | dev workspace        | dev-{{template `model_name` .}}     | /dev-{{template `experiment_base_name` .}}     |
-| staging     | The `staging` environment is part of the CD pipeline. Latest {{template `default_branch` .}} content will be deployed to staging workspace with `staging` environment config.                                                             | staging workspace    | staging-{{template `model_name` .}} | /staging-{{template `experiment_base_name` .}} |
-| prod        | The `prod` environment is part of the CD pipeline. Latest {{template `release_branch` .}} content will be deployed to prod workspace with `prod` environment config.                                                                      | prod workspace       | prod-{{template `model_name` .}}    | /prod-{{template `experiment_base_name` .}}    |
-| test        | The `test` environment is part of the CI pipeline. For changes targeting the {{template `default_branch` .}} branch, upon making a PR, an integration test will be triggered and ML resources deployed to the staging workspace defined under `test` environment. | staging workspace    | test-{{template `model_name` .}}    | /test-{{template `experiment_base_name` .}}    |
+| dev         | The `dev` deployment target is used by ML engineers to deploy ML resources to development workspace with `dev` configs. The config is for ML project development purposes.                                                           | dev workspace        | dev-{{template `model_name` .}}     | /dev-{{template `experiment_base_name` .}}     |
+| staging     | The `staging` deployment target is part of the CD pipeline. Latest {{template `default_branch` .}} content will be deployed to staging workspace with `staging` config.                                                             | staging workspace    | staging-{{template `model_name` .}} | /staging-{{template `experiment_base_name` .}} |
+| prod        | The `prod` deployment target is part of the CD pipeline. Latest {{template `release_branch` .}} content will be deployed to prod workspace with `prod` config.                                                                      | prod workspace       | prod-{{template `model_name` .}}    | /prod-{{template `experiment_base_name` .}}    |
+| test        | The `test` deployment target is part of the CI pipeline. For changes targeting the {{template `default_branch` .}} branch, upon making a PR, an integration test will be triggered and ML resources deployed to the staging workspace defined under `test` deployment target. | staging workspace    | test-{{template `model_name` .}}    | /test-{{template `experiment_base_name` .}}    |
 
-During ML code development, you can deploy local ML resource configurations together with ML code to the a Databricks workspace to run the training, model validation or batch inference pipelines. The deployment will use `dev` environment config by default. 
+During ML code development, you can deploy local ML resource configurations together with ML code to the a Databricks workspace to run the training, model validation or batch inference pipelines. The deployment will use `dev` config by default.
 
 You can open a PR (pull request) to modify ML code or the resource config against {{template `default_branch` .}} branch.
 The PR will trigger Python unit tests, followed by an integration test executed on the staging workspace, as defined under the `test` environment resource. 

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/batch-inference-workflow-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/batch-inference-workflow-resource.yml.tmpl
@@ -14,17 +14,17 @@ permissions: &permissions
 resources:
   jobs:
     batch_inference_job:
-      name: ${bundle.environment}-{{template `project_name` .}}-batch-inference-job
+      name: ${bundle.target}-{{template `project_name` .}}-batch-inference-job
       tasks:
         - task_key: batch_inference_job
           <<: *new_cluster
           notebook_task:
             notebook_path: ../deployment/batch_inference/notebooks/BatchInference.py
             base_parameters:
-              env: ${bundle.environment}
+              env: ${bundle.target}
               {{ if (eq .input_include_feature_store `yes`) }}input_table_name: hive_metastore.default.taxi_scoring_sample_feature_store_inference_input
               {{- else -}}input_table_name: taxi_scoring_sample{{ end }}
-              output_table_name: ${bundle.environment}_{{template `project_name_alphanumeric_underscore` .}}_predictions
+              output_table_name: ${bundle.target}_{{template `project_name_alphanumeric_underscore` .}}_predictions
               model_name: ${var.model_name}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/feature-engineering-workflow-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/feature-engineering-workflow-resource.yml.tmpl
@@ -14,7 +14,7 @@ permissions: &permissions
 resources:
   jobs:
     write_feature_table_job:
-      name: ${bundle.environment}-{{template `project_name` .}}-write-feature-table-job
+      name: ${bundle.target}-{{template `project_name` .}}-write-feature-table-job
       job_clusters:
         - job_cluster_key: write_feature_table_job_cluster
           <<: *new_cluster
@@ -30,7 +30,7 @@ resources:
               input_start_date: ""
               input_end_date: ""
               timestamp_column: tpep_pickup_datetime
-              output_table_name: feature_store_taxi_example.${bundle.environment}_{{template `project_name_alphanumeric_underscore` .}}_trip_pickup_features
+              output_table_name: feature_store_taxi_example.${bundle.target}_{{template `project_name_alphanumeric_underscore` .}}_trip_pickup_features
               features_transform_module: pickup_features
               primary_keys: zip
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
@@ -46,7 +46,7 @@ resources:
               input_start_date: ""
               input_end_date: ""
               timestamp_column: tpep_dropoff_datetime
-              output_table_name: feature_store_taxi_example.${bundle.environment}_{{template `project_name_alphanumeric_underscore` .}}_trip_dropoff_features
+              output_table_name: feature_store_taxi_example.${bundle.target}_{{template `project_name_alphanumeric_underscore` .}}_trip_dropoff_features
               features_transform_module: dropoff_features
               primary_keys: zip
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/ml-artifacts-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/ml-artifacts-resource.yml.tmpl
@@ -1,22 +1,22 @@
-# Environment specific values
-environments:
+# Target(environment) specific values
+targets:
   dev:
     resources:
       models:
         model:
-          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.environment} environment.
+          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.target} environment.
 
   test:
     resources:
       models:
         model:
-          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.environment} environment.
+          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.target} environment.
 
   staging:
     resources:
       models:
         model:
-          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.environment} environment.
+          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.target} environment.
 
   prod:
     resources:
@@ -28,7 +28,7 @@ environments:
             Links:
               * [Git Repo]($#{var.git_repo_url}): contains ML code for the current project.
               * [Recurring model training job]({{template `databricks_staging_workspace_host` .}}#job/${resources.jobs.model_training_job.id}): trains fresh model versions using the latest ML code.
-              * [Recurring batch inference job]({{template `databricks_staging_workspace_host` .}}#job/${resources.jobs.batch_inference_job.id}): applies the latest ${bundle.environment} model version for batch inference.
+              * [Recurring batch inference job]({{template `databricks_staging_workspace_host` .}}#job/${resources.jobs.batch_inference_job.id}): applies the latest ${bundle.target} model version for batch inference.
 
 # Allow users to read the model and experiment
 permissions: &permissions

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/ml-artifacts-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/ml-artifacts-resource.yml.tmpl
@@ -4,19 +4,19 @@ targets:
     resources:
       models:
         model:
-          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.target} environment.
+          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.target} deployment target.
 
   test:
     resources:
       models:
         model:
-          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.target} environment.
+          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.target} deployment target.
 
   staging:
     resources:
       models:
         model:
-          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.target} environment.
+          description: MLflow registered model for the "{{template `project_name` .}}" ML Project for ${bundle.target} deployment target.
 
   prod:
     resources:

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/ml-artifacts-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/ml-artifacts-resource.yml.tmpl
@@ -1,4 +1,4 @@
-# Target(environment) specific values
+# Deployment target specific values
 targets:
   dev:
     resources:

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/model-workflow-resource.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks-resources/model-workflow-resource.yml.tmpl
@@ -14,7 +14,7 @@ permissions: &permissions
 resources:
   jobs:
     model_training_job:
-      name: ${bundle.environment}-{{template `project_name` .}}-model-training-job
+      name: ${bundle.target}-{{template `project_name` .}}-model-training-job
       job_clusters:
         - job_cluster_key: model_training_job_cluster
           <<: *new_cluster
@@ -24,7 +24,7 @@ resources:
           {{ if and (eq .input_include_feature_store `no`) (eq .input_include_mlflow_recipes `no`) }}notebook_task:
             notebook_path: ../training/notebooks/Train.py
             base_parameters:
-              env: ${bundle.environment}
+              env: ${bundle.target}
               # TODO: Update training_data_path
               training_data_path: /databricks-datasets/nyctaxi-with-zipcodes/subsampled
               experiment_name: ${var.experiment_name}
@@ -34,19 +34,19 @@ resources:
           {{ else if (eq .input_include_feature_store `yes`) }}notebook_task:
             notebook_path: ../training/notebooks/TrainWithFeatureStore.py
             base_parameters:
-              env: ${bundle.environment}
+              env: ${bundle.target}
               # TODO: Update training_data_path
               training_data_path: /databricks-datasets/nyctaxi-with-zipcodes/subsampled
               experiment_name: ${var.experiment_name}
               model_name: ${var.model_name}
-              pickup_features_table: feature_store_taxi_example.${bundle.environment}_{{template `project_name_alphanumeric_underscore` .}}_trip_pickup_features
-              dropoff_features_table: feature_store_taxi_example.${bundle.environment}_{{template `project_name_alphanumeric_underscore` .}}_trip_dropoff_features
+              pickup_features_table: feature_store_taxi_example.${bundle.target}_{{template `project_name_alphanumeric_underscore` .}}_trip_pickup_features
+              dropoff_features_table: feature_store_taxi_example.${bundle.target}_{{template `project_name_alphanumeric_underscore` .}}_trip_dropoff_features
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
           {{- else -}}notebook_task:
             notebook_path: ../training/notebooks/TrainWithMLflowRecipes.py
             base_parameters:
-              env: ${bundle.environment}
+              env: ${bundle.target}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}{{ end }}
         - task_key: ModelValidation
@@ -57,7 +57,7 @@ resources:
             notebook_path: ../validation/notebooks/ModelValidation.py
             base_parameters:
               {{- if (eq .input_include_mlflow_recipes `yes`) }}
-              env: ${bundle.environment}{{ end }}
+              env: ${bundle.target}{{ end }}
               experiment_name: ${var.experiment_name}
               # The `run_mode` defines whether model validation is enabled or not.
               # It can be one of the three values:
@@ -102,7 +102,7 @@ resources:
           notebook_task:
             notebook_path: ../deployment/model_deployment/notebooks/ModelDeployment.py
             base_parameters:
-              env: ${bundle.environment}
+              env: ${bundle.target}
               # git source information of current ML resource deployment. It will be persisted as part of the workflow run
               git_source_info: url:${bundle.git.origin_url}; branch:${bundle.git.branch}; commit:${bundle.git.commit}
       schedule:

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks.yml.tmpl
@@ -6,10 +6,10 @@ bundle:
 variables:
   experiment_name:
     description: Experiment name for the model training.
-    default: /Users/${workspace.current_user.userName}/${bundle.environment}-{{template `experiment_base_name` .}}
+    default: /Users/${workspace.current_user.userName}/${bundle.target}-{{template `experiment_base_name` .}}
   model_name:
     description: Model name for the model training.
-    default: ${bundle.environment}-{{template `model_name` .}}
+    default: ${bundle.target}-{{template `model_name` .}}
 
 
 include:
@@ -29,8 +29,8 @@ include:
   - ./databricks-resources/monitoring-workflow-resource.yml
 
 
-# Environment specific values for workspace
-environments:
+# Target(environment) specific values for workspace
+targets:
   dev:
     default: true
     workspace:

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks.yml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/databricks.yml.tmpl
@@ -29,7 +29,7 @@ include:
   - ./databricks-resources/monitoring-workflow-resource.yml
 
 
-# Target(environment) specific values for workspace
+# Deployment Target specific values for workspace
 targets:
   dev:
     default: true

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-dev.yaml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-dev.yaml.tmpl
@@ -1,8 +1,8 @@
 # This profile contains config overrides for model development on Databricks
 experiment:
-  # The name of the experiment to use during training or model validation in dev environment.
+  # The name of the experiment to use during training or model validation in dev target(environment).
   # TODO: This value must be the same as experiment_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for dev environment.
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for dev target(environment).
   name: /dev-{{template `experiment_base_name` .}}
 
 # Set the registry server URI. This property is especially useful if you have a registry
@@ -10,7 +10,7 @@ experiment:
 model_registry:
   # Specify the MLflow registered model name under which to register model versions
   # This value must be the same as model_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for dev environment.
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for dev target(environment).
   model_name: dev-{{template `model_name` .}}
 
 # Override the default train / validation / test dataset split ratios

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-dev.yaml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-dev.yaml.tmpl
@@ -1,8 +1,8 @@
 # This profile contains config overrides for model development on Databricks
 experiment:
-  # The name of the experiment to use during training or model validation in dev target(environment).
+  # The name of the experiment to use during training or model validation in dev deployment target.
   # TODO: This value must be the same as experiment_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for dev target(environment).
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for dev deployment target.
   name: /dev-{{template `experiment_base_name` .}}
 
 # Set the registry server URI. This property is especially useful if you have a registry
@@ -10,7 +10,7 @@ experiment:
 model_registry:
   # Specify the MLflow registered model name under which to register model versions
   # This value must be the same as model_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for dev target(environment).
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for dev deployment target.
   model_name: dev-{{template `model_name` .}}
 
 # Override the default train / validation / test dataset split ratios

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-prod.yaml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-prod.yaml.tmpl
@@ -1,7 +1,7 @@
 experiment:
-  # The name of the experiment to use during training or model validation in prod environment.
+  # The name of the experiment to use during training or model validation in prod target(environment).
   # TODO: This value must be the same as experiment_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for prod environment.
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for prod target(environment).
   name: /prod-{{template `experiment_base_name` .}}
 
 # Set the registry server URI. This property is especially useful if you have a registry
@@ -9,7 +9,7 @@ experiment:
 model_registry:
   # The MLflow registered model name under which to register model versions
   # This value must be the same as model_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for prod environment.
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for prod target(environment).
   model_name: prod-{{template `model_name` .}}
 
 # Override the default train / validation / test dataset split ratios

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-prod.yaml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-prod.yaml.tmpl
@@ -1,7 +1,7 @@
 experiment:
-  # The name of the experiment to use during training or model validation in prod target(environment).
+  # The name of the experiment to use during training or model validation in prod deployment target.
   # TODO: This value must be the same as experiment_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for prod target(environment).
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for prod deployment target.
   name: /prod-{{template `experiment_base_name` .}}
 
 # Set the registry server URI. This property is especially useful if you have a registry
@@ -9,7 +9,7 @@ experiment:
 model_registry:
   # The MLflow registered model name under which to register model versions
   # This value must be the same as model_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for prod target(environment).
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for prod deployment target.
   model_name: prod-{{template `model_name` .}}
 
 # Override the default train / validation / test dataset split ratios

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-staging.yaml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-staging.yaml.tmpl
@@ -1,7 +1,7 @@
 experiment:
-  # The name of the experiment to use during training or model validation in staging environment.
+  # The name of the experiment to use during training or model validation in staging target(environment).
   # TODO: This value must be the same as experiment_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for staging environment.
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for staging target(environment).
   name: /staging-{{template `experiment_base_name` .}}
 
 # Set the registry server URI. This property is especially useful if you have a registry
@@ -9,7 +9,7 @@ experiment:
 model_registry:
   # The MLflow registered model name under which to register model versions
   # This value must be the same as model_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for staging environment.
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for staging target(environment).
   model_name: staging-{{template `model_name` .}}
 
 # Override the default train / validation / test dataset split ratios

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-staging.yaml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-staging.yaml.tmpl
@@ -1,7 +1,7 @@
 experiment:
-  # The name of the experiment to use during training or model validation in staging target(environment).
+  # The name of the experiment to use during training or model validation in staging deployment target.
   # TODO: This value must be the same as experiment_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for staging target(environment).
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for staging deployment target.
   name: /staging-{{template `experiment_base_name` .}}
 
 # Set the registry server URI. This property is especially useful if you have a registry
@@ -9,7 +9,7 @@ experiment:
 model_registry:
   # The MLflow registered model name under which to register model versions
   # This value must be the same as model_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for staging target(environment).
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for staging deployment target.
   model_name: staging-{{template `model_name` .}}
 
 # Override the default train / validation / test dataset split ratios

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-test.yaml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-test.yaml.tmpl
@@ -1,7 +1,7 @@
 experiment:
-  # The name of the experiment to use during training or model validation in test environment.
+  # The name of the experiment to use during training or model validation in test target(environment).
   # TODO: This value must be the same as experiment_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for test environment.
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for test target(environment).
   name: /test-{{template `experiment_base_name` .}}
 
 # Set the registry server URI. This property is especially useful if you have a registry
@@ -10,7 +10,7 @@ model_registry:
   # Specifies the name of the Registered Model to use when registering a trained model to
   # the MLflow Model Registry
   # This value must be the same as model_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for test environment.
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for test target(environment).
   model_name: test-{{template `model_name` .}}
 
 # Override the default train / validation / test dataset split ratios

--- a/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-test.yaml.tmpl
+++ b/template/{{.input_root_dir}}/{{template `project_name_alphanumeric_underscore` .}}/training/profiles/databricks-test.yaml.tmpl
@@ -1,7 +1,7 @@
 experiment:
-  # The name of the experiment to use during training or model validation in test target(environment).
+  # The name of the experiment to use during training or model validation in test deployment target.
   # TODO: This value must be the same as experiment_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for test target(environment).
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for test deployment target.
   name: /test-{{template `experiment_base_name` .}}
 
 # Set the registry server URI. This property is especially useful if you have a registry
@@ -10,7 +10,7 @@ model_registry:
   # Specifies the name of the Registered Model to use when registering a trained model to
   # the MLflow Model Registry
   # This value must be the same as model_name defined in
-  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for test target(environment).
+  # {{template `project_name_alphanumeric_underscore` .}}/databricks.yml for test deployment target.
   model_name: test-{{template `model_name` .}}
 
 # Override the default train / validation / test dataset split ratios


### PR DESCRIPTION
Replace `environments` with `targets` in bundle schema.
Use `-t` instead of `-e` in bundle commands.

## Test
staging bundle deployment github action https://github.com/mingyu89/test-repo1/actions/runs/6191961364
prod bundle deployment github action https://github.com/mingyu89/test-repo1/actions/runs/6191963013 
CI https://github.com/mingyu89/test-repo1/actions/runs/6191956553/job/16811199686
example PR https://github.com/mingyu89/test-repo1/pull/32
<img width="1342" alt="Screenshot 2023-09-14 at 4 55 16 PM" src="https://github.com/databricks/mlops-stack/assets/12734110/e30bec39-3a63-404a-9fba-bab21b1c9b60">



Example test workflow https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#job/695637851058465
<img width="969" alt="Screenshot 2023-09-14 at 4 55 58 PM" src="https://github.com/databricks/mlops-stack/assets/12734110/dc316191-1c50-4cd7-bae4-c8bb4544504e">
